### PR TITLE
apply appBarHeight for header (animated-view) on android

### DIFF
--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -599,9 +599,11 @@ class Header extends React.PureComponent {
             backgroundColor:
               safeHeaderStyle.backgroundColor || DEFAULT_BACKGROUND_COLOR,
           }
-        : Platform.OS === 'android' && mode === 'float' && options.headerTransparent
-            ? { height: safeHeaderStyle.height || appBarHeight }
-            : null
+        : Platform.OS === 'android' &&
+          mode === 'float' &&
+          options.headerTransparent
+          ? { height: safeHeaderStyle.height || appBarHeight }
+          : null,
     ];
 
     const containerStyles = [

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -592,6 +592,18 @@ class Header extends React.PureComponent {
     }
 
     // TODO: warn if any unsafe styles are provided
+    const animatedViewStyles = [
+      this.props.layoutInterpolator(this.props),
+      Platform.OS === 'ios' && !options.headerTransparent
+        ? {
+            backgroundColor:
+              safeHeaderStyle.backgroundColor || DEFAULT_BACKGROUND_COLOR,
+          }
+        : Platform.OS === 'android' && mode === 'float' && options.headerTransparent
+            ? { height: safeHeaderStyle.height || appBarHeight }
+            : null
+    ];
+
     const containerStyles = [
       options.headerTransparent
         ? styles.transparentContainer
@@ -604,17 +616,7 @@ class Header extends React.PureComponent {
     const forceInset = headerForceInset || { top: 'always', bottom: 'never' };
 
     return (
-      <Animated.View
-        style={[
-          this.props.layoutInterpolator(this.props),
-          Platform.OS === 'ios' && !options.headerTransparent
-            ? {
-                backgroundColor:
-                  safeHeaderStyle.backgroundColor || DEFAULT_BACKGROUND_COLOR,
-              }
-            : null,
-        ]}
-      >
+      <Animated.View style={animatedViewStyles}>
         <SafeAreaView forceInset={forceInset} style={containerStyles}>
           {background}
           <View style={styles.flexOne}>{appBar}</View>


### PR DESCRIPTION
this is my take on issue react-navigation/react-navigation#4872.

Although react-native v0.57.0 [fixing ](https://github.com/facebook/react-native/commit/b81c8b51fc6fe3c2dece72e3fe500e175613c5d4) clip children on android, I don't believe  it will take care of touches on clipped views, soon.

header is shown alright,  but because it is not touchable, the back button is not clickable :(

I tried to apply a "fix" just for the current problem and not affected all the others code paths (there are many), so the change is for `android + float mode + transparent` only. 
