### PR TITLE
Add Vertical Gesture Directions

### DIFF
--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -368,7 +368,14 @@ class StackViewLayout extends React.Component {
   };
 
   _isMotionVertical = () => {
-    return this._isModal();
+    const {
+      transitionProps: { scene },
+    } = this.props;
+    const { options } = scene.descriptor;
+    const { gestureDirection } = options;
+    return this._isModal() ||
+      gestureDirection === 'up' ||
+      gestureDirection === 'down';
   };
 
   _isModal = () => {


### PR DESCRIPTION
This PR allows for both horizontal and vertical gesture directions to be used within a single navigator.

A use case is as follows: A navigator with a mode of "card" should default to a horizontal gesture direction. However if there is a select subset of screens in the navigator that I wish to have a vertical gesture direction, I can set `gestureDirection` to "up" or "down" in the navigationOptions of those screens.