### PR TITLE
export floatingHeaderHeight as a function when headerMode is float

### DIFF
--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -120,14 +120,14 @@ class StackViewLayout extends React.Component {
         useNativeDriver: USE_NATIVE_DRIVER,
       }
     );
-
+    const getHeaderHeight = props.floatingHeaderHeight || getDefaultHeaderHeight;
     this.state = {
       // Used when card's header is null and mode is float to make transition
       // between screens with headers and those without headers smooth.
       // This is not a great heuristic here. We don't know synchronously
       // on mount what the header height is so we have just used the most
       // common cases here.
-      floatingHeaderHeight: getDefaultHeaderHeight(props.isLandscape),
+      floatingHeaderHeight: getHeaderHeight(props.isLandscape),
     };
   }
 


### PR DESCRIPTION
fix screen flickering on Android when `headerMode` is `float` and `header` height is not 56. Enable user to specify default floating header height.

related to [this issue](https://github.com/react-navigation/react-navigation-stack/issues/83)