### PR TITLE
Ios header shadow

### DIFF
--- a/src/navigators/__tests__/__snapshots__/NestedNavigator-test.js.snap
+++ b/src/navigators/__tests__/__snapshots__/NestedNavigator-test.js.snap
@@ -169,13 +169,18 @@ exports[`Nested navigators renders succesfully as direct child 1`] = `
                         style={
                           Object {
                             "backgroundColor": "#FFF",
-                            "borderBottomColor": "#A7A7AA",
-                            "borderBottomWidth": 0.5,
                             "height": 64,
                             "paddingBottom": 0,
                             "paddingLeft": 0,
                             "paddingRight": 0,
                             "paddingTop": 20,
+                            "shadowColor": "rgba(0, 0, 0, 0.3)",
+                            "shadowOffset": Object {
+                              "height": 0.5,
+                              "width": 0,
+                            },
+                            "shadowOpacity": 0.85,
+                            "shadowRadius": 0,
                           }
                         }
                       >
@@ -272,13 +277,18 @@ exports[`Nested navigators renders succesfully as direct child 1`] = `
             style={
               Object {
                 "backgroundColor": "#FFF",
-                "borderBottomColor": "#A7A7AA",
-                "borderBottomWidth": 0.5,
                 "height": 64,
                 "paddingBottom": 0,
                 "paddingLeft": 0,
                 "paddingRight": 0,
                 "paddingTop": 20,
+                "shadowColor": "rgba(0, 0, 0, 0.3)",
+                "shadowOffset": Object {
+                  "height": 0.5,
+                  "width": 0,
+                },
+                "shadowOpacity": 0.85,
+                "shadowRadius": 0,
               }
             }
           >

--- a/src/navigators/__tests__/__snapshots__/StackNavigator-test.js.snap
+++ b/src/navigators/__tests__/__snapshots__/StackNavigator-test.js.snap
@@ -101,14 +101,19 @@ exports[`StackNavigator applies correct values when headerRight is present 1`] =
             style={
               Object {
                 "backgroundColor": "red",
-                "borderBottomColor": "#A7A7AA",
-                "borderBottomWidth": 0.5,
                 "height": 64,
                 "opacity": 0.5,
                 "paddingBottom": 0,
                 "paddingLeft": 0,
                 "paddingRight": 0,
                 "paddingTop": 20,
+                "shadowColor": "rgba(0, 0, 0, 0.3)",
+                "shadowOffset": Object {
+                  "height": 0.5,
+                  "width": 0,
+                },
+                "shadowOpacity": 0.85,
+                "shadowRadius": 0,
               }
             }
           >
@@ -294,14 +299,19 @@ exports[`StackNavigator renders successfully 1`] = `
             style={
               Object {
                 "backgroundColor": "red",
-                "borderBottomColor": "#A7A7AA",
-                "borderBottomWidth": 0.5,
                 "height": 64,
                 "opacity": 0.5,
                 "paddingBottom": 0,
                 "paddingLeft": 0,
                 "paddingRight": 0,
                 "paddingTop": 20,
+                "shadowColor": "rgba(0, 0, 0, 0.3)",
+                "shadowOffset": Object {
+                  "height": 0.5,
+                  "width": 0,
+                },
+                "shadowOpacity": 0.85,
+                "shadowRadius": 0,
               }
             }
           >

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -646,8 +646,13 @@ const platformContainerStyles = Platform.select({
     elevation: 4,
   },
   ios: {
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#A7A7AA',
+    shadowColor: 'rgba(0, 0, 0, 0.3)',
+    shadowOpacity: 0.85,
+    shadowRadius: 0,
+    shadowOffset: {
+      width: 0,
+      height: StyleSheet.hairlineWidth,
+    },
   },
   default: {},
 });


### PR DESCRIPTION
Use `shadow` properties for iOS header instead of `border` properties as described in [this issue](https://github.com/react-navigation/react-navigation/issues/4865).