### PR TITLE
[wip] export header-height-related functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,4 +60,10 @@ module.exports = {
   get StackGestureContext() {
     return require('./utils/StackGestureContext').default;
   },
+  get getAppBarHeight() {
+    return require('./views/Header/Header').getAppBarHeight;
+  },
+  get getDefaultHeaderHeight() {
+    return require('./views/StackView/StackViewLayout').getDefaultHeaderHeight;
+  },
 };

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -61,7 +61,7 @@ const getTitleOffsets = (
   }
 };
 
-const getAppBarHeight = isLandscape => {
+export const getAppBarHeight = isLandscape => {
   return Platform.OS === 'ios'
     ? isLandscape && !Platform.isPad
       ? 32

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -69,7 +69,7 @@ const GESTURE_RESPONSE_DISTANCE_VERTICAL = 135;
 
 const USE_NATIVE_DRIVER = true;
 
-const getDefaultHeaderHeight = isLandscape => {
+export const getDefaultHeaderHeight = isLandscape => {
   if (Platform.OS === 'ios') {
     if (isLandscape && !Platform.isPad) {
       return 32;


### PR DESCRIPTION
there are some use cases (for me this is header animations) where it is handy to know how tall parts of the header are, and for these it would be handy to export the functions that do these computations