### PR TITLE
[web] Use portals to float the header at the body level

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,5 +117,8 @@
       "module",
       "typescript"
     ]
+  },
+  "dependencies": {
+    "@types/react-dom": "^16.8.4"
   }
 }

--- a/src/views/Header/HeaderContainer.tsx
+++ b/src/views/Header/HeaderContainer.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export class NavContainer extends React.PureComponent {
+  render() {
+    return this.props.children;
+  }
+}
+
+export class HeaderPortal extends React.PureComponent {
+  render() {
+    return this.props.children;
+  }
+}
+
+export default class HeaderContainer extends React.PureComponent {
+  render() {
+    return this.props.children;
+  }
+}

--- a/src/views/Header/HeaderContainer.web.tsx
+++ b/src/views/Header/HeaderContainer.web.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+declare const document: Document;
+
+export class NavContainer extends React.PureComponent {
+  render() {
+    return (
+      <header>
+        <nav role="navigation">{this.props.children}</nav>
+      </header>
+    );
+  }
+}
+
+export class HeaderPortal extends React.PureComponent {
+  render() {
+    return ReactDOM.createPortal(this.props.children, document.body);
+  }
+}
+
+export default class HeaderContainer extends React.PureComponent {
+  render() {
+    const { children } = this.props;
+    return (
+      <HeaderPortal>
+        <NavContainer>{children}</NavContainer>
+      </HeaderPortal>
+    );
+  }
+}

--- a/src/views/StackView/StackViewLayout.tsx
+++ b/src/views/StackView/StackViewLayout.tsx
@@ -26,7 +26,7 @@ import {
   GestureHandlerGestureEventNativeEvent,
   PanGestureHandlerEventExtra,
 } from 'react-native-gesture-handler';
-
+import HeaderContainer from '../Header/HeaderContainer';
 import Card from './StackViewCard';
 import Header from '../Header/Header';
 import TransitionConfigs from './StackViewTransitionConfigs';
@@ -358,13 +358,15 @@ class StackViewLayout extends React.Component<Props, State> {
     if (headerMode === 'float') {
       const { scene } = transitionProps;
       floatingHeader = (
-        <View
-          style={styles.floatingHeader}
-          pointerEvents="box-none"
-          onLayout={this.handleFloatingHeaderLayout}
-        >
-          {this.renderHeader(scene, headerMode)}
-        </View>
+        <HeaderContainer>
+          <View
+            style={styles.floatingHeader}
+            pointerEvents="box-none"
+            onLayout={this.handleFloatingHeaderLayout}
+          >
+            {this.renderHeader(scene, headerMode)}
+          </View>
+        </HeaderContainer>
       );
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",
-    "lib": ["esnext"],
+    "lib": ["dom", "esnext"],
     "module": "esnext",
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,3 +5,5 @@ declare module '*.png' {
 
   export default value;
 }
+
+declare module 'react-dom';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1141,6 +1141,13 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
   integrity sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==
 
+"@types/react-dom@^16.8.4":
+  version "16.8.4"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.4.tgz#7fb7ba368857c7aa0f4e4511c4710ca2c5a12a88"
+  integrity sha512-eIRpEW73DCzPIMaNBDP5pPIpK1KXyZwNgfxiVagb5iGiz6da+9A5hslSX6GAQKdO7SayVCS/Fr2kjqprgAvkfA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-native@^0.57.51":
   version "0.57.51"
   resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.57.51.tgz#adcb02141734b72822848351be734971e508f5f1"


### PR DESCRIPTION
On web the header element should be at the body level so it sticks to the url bar when the screen overflows. This makes floating headers feel much better on web. 
Demo here: https://5cd0a891535a11ac2fd2fc1d--europe.netlify.com