### PR TITLE
feat: allow overriding headerLayoutInterpolator

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -67,6 +67,7 @@ export type HeaderProps = {
   titleInterpolator: (props: SceneInterpolatorProps) => any;
   rightInterpolator: (props: SceneInterpolatorProps) => any;
   backgroundInterpolator: (props: SceneInterpolatorProps) => any;
+  layoutInterpolator?: (props: SceneInterpolatorProps) => any;
   isLandscape: boolean;
 };
 

--- a/src/views/StackView/StackViewLayout.tsx
+++ b/src/views/StackView/StackViewLayout.tsx
@@ -226,6 +226,7 @@ class StackViewLayout extends React.Component<Props, State> {
       headerTitleInterpolator,
       headerRightInterpolator,
       headerBackgroundInterpolator,
+      headerLayoutInterpolator,
     } = this.transitionConfig as HeaderTransitionConfig;
 
     const backgroundTransitionPresetInterpolator = this.getHeaderBackgroundTransitionPreset();
@@ -250,6 +251,7 @@ class StackViewLayout extends React.Component<Props, State> {
           titleInterpolator: headerTitleInterpolator,
           rightInterpolator: headerRightInterpolator,
           backgroundInterpolator: headerBackgroundInterpolator,
+          layoutInterpolator: headerLayoutInterpolator,
         })}
       </NavigationProvider>
     );


### PR DESCRIPTION
This makes it possible to do animations where the header does not come in from the left when navigating from one screen to another.