### PR TITLE
Silence deprecated lifecycle warning in Transitioner

### DIFF
--- a/src/views/Transitioner.tsx
+++ b/src/views/Transitioner.tsx
@@ -117,7 +117,7 @@ class Transitioner extends React.Component<Props, State> {
       this.state.position.removeListener(this.positionListener);
   }
 
-  componentWillReceiveProps(nextProps: Props) {
+  UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (this.isTransitionRunning) {
       if (!this.queuedTransition) {
         this.queuedTransition = { prevProps: this.props };


### PR DESCRIPTION
I don't feel confident trying to migrate this thing to `getDerivedStateFromProps` so...  `componentWillReceiveProps` -> `UNSAFE_componentWillReceiveProps`