### PR TITLE
Make listeners more reliable

### DIFF
--- a/src/views/Stack/Card.tsx
+++ b/src/views/Stack/Card.tsx
@@ -305,6 +305,7 @@ export default class Card extends React.Component<Props> {
           )
         ),
         // Stop animations while we're dragging
+        // and invoke proper listener
         cond(
           clockRunning(this.clock),
           call([this.toValue], ([target]) => {
@@ -379,6 +380,9 @@ export default class Card extends React.Component<Props> {
   ]);
 
   componentWillUnmount(): void {
+    // It might sometimes happen than animation will be unmounted
+    // during running. However, we need to invoke listener onClose
+    // manually in this case
     if (this.isRunningAnimation) {
       this.props.onClose(false);
     }


### PR DESCRIPTION
## Fixes
This PR helps in two cases

1. The animation is not finished and the component is being unmounted. I manually invoke `onClose` method in this case.

2. Gesture breaks an animation's running. I manually invoke a proper listener in this case.
