### PR TITLE
fix: make container visible on web

### DIFF
--- a/src/views/StackView/StackViewLayout.tsx
+++ b/src/views/StackView/StackViewLayout.tsx
@@ -962,7 +962,7 @@ class StackViewLayout extends React.Component<Props, State> {
 
     if (hasHeader && headerMode === 'float' && !options.headerTransparent) {
       floatingContainerStyle = {
-        ...Platform.select({ web: {}, default: StyleSheet.absoluteFillObject }),
+        ...StyleSheet.absoluteFillObject,
         paddingTop: this.state.floatingHeaderHeight,
       };
     }


### PR DESCRIPTION
Currently, the container is not visible on web (also mentioned here: https://github.com/react-navigation/stack/commit/e1955504652ccf8ee6b2da0d28ad369894266a23#r33931144). I'm not sure why there was a platform distinction before but maybe @EvanBacon could comment on this?