### PR TITLE
[web] Change default header styles and mode

### DIFF
--- a/src/views/Header/Header.tsx
+++ b/src/views/Header/Header.tsx
@@ -734,9 +734,8 @@ const platformContainerStyles = Platform.select({
     borderBottomColor: '#A7A7AA',
   },
   default: {
-    // https://github.com/necolas/react-native-web/issues/44
-    // Material Design
-    boxShadow: `0 2px 4px -1px rgba(0,0,0,0.2), 0 4px 5px 0 rgba(0,0,0,0.14), 0 1px 10px 0 rgba(0,0,0,0.12)`,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: 'rgba(156, 156, 156, 0.50)',
   },
 });
 

--- a/src/views/StackView/StackViewLayout.tsx
+++ b/src/views/StackView/StackViewLayout.tsx
@@ -766,7 +766,7 @@ class StackViewLayout extends React.Component<Props, State> {
     if (this.props.headerMode) {
       return this.props.headerMode;
     }
-    if (Platform.OS === 'android' || this.props.mode === 'modal') {
+    if (Platform.OS !== 'ios' || this.props.mode === 'modal') {
       return 'screen';
     }
     // On web, the float header mode will enable body scrolling and stick the header


### PR DESCRIPTION
* Change stack navigation header style in the browser to be as simple as possible
* Make the default headerMode for web be screen as float conflicts with the tab nav, effectively preventing all scrolling.