### PR TITLE
feat: pass navigationOptions to cardInterpolator

### DIFF
--- a/src/navigators/__tests__/__snapshots__/NestedNavigator.test.tsx.snap
+++ b/src/navigators/__tests__/__snapshots__/NestedNavigator.test.tsx.snap
@@ -34,6 +34,7 @@ Array [
         onGestureEnd={[Function]}
         onOpen={[Function]}
         onTransitionStart={[Function]}
+        options={Object {}}
         pointerEvents="box-none"
         style={
           Object {
@@ -187,6 +188,7 @@ Array [
                       onGestureEnd={[Function]}
                       onOpen={[Function]}
                       onTransitionStart={[Function]}
+                      options={Object {}}
                       pointerEvents="box-none"
                       style={
                         Object {

--- a/src/navigators/__tests__/__snapshots__/StackNavigator.test.tsx.snap
+++ b/src/navigators/__tests__/__snapshots__/StackNavigator.test.tsx.snap
@@ -34,6 +34,21 @@ Array [
         onGestureEnd={[Function]}
         onOpen={[Function]}
         onTransitionStart={[Function]}
+        options={
+          Object {
+            "gesturesEnabled": true,
+            "headerRight": [Function],
+            "headerStyle": Array [
+              Object {
+                "backgroundColor": "red",
+              },
+              Object {
+                "opacity": 0.5,
+              },
+            ],
+            "title": "Welcome anonymous",
+          }
+        }
         pointerEvents="box-none"
         style={
           Object {
@@ -352,6 +367,20 @@ Array [
         onGestureEnd={[Function]}
         onOpen={[Function]}
         onTransitionStart={[Function]}
+        options={
+          Object {
+            "gesturesEnabled": true,
+            "headerStyle": Array [
+              Object {
+                "backgroundColor": "red",
+              },
+              Object {
+                "opacity": 0.5,
+              },
+            ],
+            "title": "Welcome anonymous",
+          }
+        }
         pointerEvents="box-none"
         style={
           Object {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -171,6 +171,7 @@ export type CardInterpolationProps = {
   layouts: {
     screen: Layout;
   };
+  options: any;
 };
 
 export type CardInterpolatedStyle = {

--- a/src/views/Stack/Card.tsx
+++ b/src/views/Stack/Card.tsx
@@ -45,6 +45,7 @@ type Props = ViewProps & {
     open: TransitionSpec;
     close: TransitionSpec;
   };
+  options: any;
   styleInterpolator: CardStyleInterpolator;
   containerStyle?: StyleProp<ViewStyle>;
   contentStyle?: StyleProp<ViewStyle>;
@@ -420,6 +421,7 @@ export default class Card extends React.Component<Props> {
         layouts: {
           screen: layout,
         },
+        options: this.props.options,
       })
   );
 

--- a/src/views/Stack/StackItem.tsx
+++ b/src/views/Stack/StackItem.tsx
@@ -121,6 +121,7 @@ export default class StackItem extends React.PureComponent<Props> {
         closing={closing}
         onOpen={this.handleOpen}
         onClose={this.handleClose}
+        options={scene.descriptor.options}
         overlayEnabled={cardOverlayEnabled}
         shadowEnabled={cardShadowEnabled}
         gesturesEnabled={gesturesEnabled}


### PR DESCRIPTION
In many apps navigation options are used as a config for custom interpolator so it's vital to pass them through. 