### PR TITLE
feat: allow specifying separate style interpolators in navigationOptions

### DIFF
--- a/example/src/HeaderBackgrounds.js
+++ b/example/src/HeaderBackgrounds.js
@@ -94,14 +94,18 @@ function createHeaderBackgroundExample(options = {}) {
   );
 }
 export const HeaderBackgroundDefault = createHeaderBackgroundExample({
-  ...TransitionPresets.SlideFromRightIOS,
-  headerStyleInterpolator: HeaderStyleInterpolators.forUIKit,
+  defaultNavigationOptions: {
+    ...TransitionPresets.SlideFromRightIOS,
+    headerStyleInterpolator: HeaderStyleInterpolators.forUIKit,
+  },
   headerMode: 'float',
 });
 
 export const HeaderBackgroundFade = createHeaderBackgroundExample({
-  ...TransitionPresets.SlideFromRightIOS,
-  headerStyleInterpolator: HeaderStyleInterpolators.forFade,
+  defaultNavigationOptions: {
+    ...TransitionPresets.SlideFromRightIOS,
+    headerStyleInterpolator: HeaderStyleInterpolators.forFade,
+  },
   headerMode: 'float',
 });
 

--- a/example/src/HeaderPreset.js
+++ b/example/src/HeaderPreset.js
@@ -105,10 +105,10 @@ const StackWithHeaderPreset = createStackNavigator(
     ScreenWithLongTitle: ScreenWithLongTitle,
   },
   {
-    ...TransitionPresets.SlideFromRightIOS,
-    headerStyleInterpolator: HeaderStyleInterpolators.forUIKit,
     headerMode: 'float',
     defaultNavigationOptions: {
+      ...TransitionPresets.SlideFromRightIOS,
+      headerStyleInterpolator: HeaderStyleInterpolators.forUIKit,
       gesturesEnabled: true,
     },
   }

--- a/example/src/ModalPresentation.js
+++ b/example/src/ModalPresentation.js
@@ -64,9 +64,9 @@ export default createStackNavigator(
     Details: DetailsScreen,
   },
   {
-    ...TransitionPresets.ModalPresentationIOS,
     mode: 'modal',
     defaultNavigationOptions: {
+      ...TransitionPresets.ModalPresentationIOS,
       cardOverlayEnabled: true,
       gesturesEnabled: true,
     },

--- a/example/src/WipeStack.js
+++ b/example/src/WipeStack.js
@@ -153,8 +153,8 @@ export default createStackNavigator(
     initialRouteName: 'List',
     headerMode: 'screen',
     defaultNavigationOptions: {
+      ...TransitionPresets.WipeFromBottomAndroid,
       cardOverlayEnabled: true,
     },
-    ...TransitionPresets.WipeFromBottomAndroid,
   }
 );

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -94,7 +94,7 @@ export type HeaderProps = {
 };
 
 export type NavigationStackOptions = HeaderOptions &
-  TransitionPreset & {
+  Partial<TransitionPreset> & {
     title?: string;
     header?: null | ((props: HeaderProps) => React.ReactNode);
     cardShadowEnabled?: boolean;
@@ -108,9 +108,6 @@ export type NavigationStackOptions = HeaderOptions &
       horizontal?: number;
     };
     disableKeyboardHandling?: boolean;
-    cardStyleInterpolator?: CardStyleInterpolator;
-    headerStyleInterpolator?: HeaderStyleInterpolator;
-    transitionPreset: TransitionPreset;
   };
 
 export type NavigationConfig = {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -107,6 +107,8 @@ export type NavigationStackOptions = HeaderOptions & {
     horizontal?: number;
   };
   disableKeyboardHandling?: boolean;
+  cardStyleInterpolator?: CardStyleInterpolator;
+  headerStyleInterpolator?: HeaderStyleInterpolator;
 };
 
 export type NavigationConfig = TransitionPreset & {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -93,25 +93,27 @@ export type HeaderProps = {
   styleInterpolator: HeaderStyleInterpolator;
 };
 
-export type NavigationStackOptions = HeaderOptions & {
-  title?: string;
-  header?: null | ((props: HeaderProps) => React.ReactNode);
-  cardShadowEnabled?: boolean;
-  cardOverlayEnabled?: boolean;
-  cardTransparent?: boolean;
-  cardStyle?: StyleProp<ViewStyle>;
-  animationEnabled?: boolean;
-  gesturesEnabled?: boolean;
-  gestureResponseDistance?: {
-    vertical?: number;
-    horizontal?: number;
+export type NavigationStackOptions = HeaderOptions &
+  TransitionPreset & {
+    title?: string;
+    header?: null | ((props: HeaderProps) => React.ReactNode);
+    cardShadowEnabled?: boolean;
+    cardOverlayEnabled?: boolean;
+    cardTransparent?: boolean;
+    cardStyle?: StyleProp<ViewStyle>;
+    animationEnabled?: boolean;
+    gesturesEnabled?: boolean;
+    gestureResponseDistance?: {
+      vertical?: number;
+      horizontal?: number;
+    };
+    disableKeyboardHandling?: boolean;
+    cardStyleInterpolator?: CardStyleInterpolator;
+    headerStyleInterpolator?: HeaderStyleInterpolator;
+    transitionPreset: TransitionPreset;
   };
-  disableKeyboardHandling?: boolean;
-  cardStyleInterpolator?: CardStyleInterpolator;
-  headerStyleInterpolator?: HeaderStyleInterpolator;
-};
 
-export type NavigationConfig = TransitionPreset & {
+export type NavigationConfig = {
   mode: 'card' | 'modal';
   headerMode: HeaderMode;
 };

--- a/src/views/Stack/Stack.tsx
+++ b/src/views/Stack/Stack.tsx
@@ -14,14 +14,11 @@ import StackItem from './StackItem';
 import {
   Route,
   Layout,
-  TransitionSpec,
-  CardStyleInterpolator,
-  HeaderStyleInterpolator,
   HeaderMode,
-  GestureDirection,
   SceneDescriptor,
   NavigationProp,
   HeaderScene,
+  TransitionPreset,
 } from '../../types';
 
 type ProgressValues = {
@@ -42,7 +39,6 @@ type Props = {
   renderHeader: (props: HeaderContainerProps) => React.ReactNode;
   renderScene: (props: { route: Route }) => React.ReactNode;
   headerMode: HeaderMode;
-  direction: GestureDirection;
   onTransitionStart?: (
     curr: { index: number },
     prev: { index: number }
@@ -50,12 +46,7 @@ type Props = {
   onGestureBegin?: () => void;
   onGestureCanceled?: () => void;
   onGestureEnd?: () => void;
-  transitionSpec: {
-    open: TransitionSpec;
-    close: TransitionSpec;
-  };
-  cardStyleInterpolator: CardStyleInterpolator;
-  headerStyleInterpolator: HeaderStyleInterpolator;
+  transitionPreset: TransitionPreset;
 };
 
 type State = {
@@ -199,14 +190,10 @@ export default class Stack extends React.Component<Props, State> {
       renderHeader,
       renderScene,
       headerMode,
-      direction,
       onTransitionStart,
       onGestureBegin,
       onGestureCanceled,
       onGestureEnd,
-      transitionSpec,
-      cardStyleInterpolator,
-      headerStyleInterpolator,
     } = this.props;
 
     const { scenes, layout, progress, floaingHeaderHeight } = this.state;
@@ -242,7 +229,13 @@ export default class Stack extends React.Component<Props, State> {
               cardOverlayEnabled,
               cardStyle,
               gestureResponseDistance,
+              transitionPreset,
             } = descriptor.options;
+
+            let computedTransitionPreset = {
+              ...this.props.transitionPreset,
+              ...transitionPreset,
+            };
 
             return (
               <AnimatedScreen
@@ -261,7 +254,6 @@ export default class Stack extends React.Component<Props, State> {
                   scene={scene}
                   previousScene={scenes[index - 1]}
                   navigation={navigation}
-                  direction={direction}
                   cardTransparent={cardTransparent}
                   cardOverlayEnabled={cardOverlayEnabled}
                   cardShadowEnabled={cardShadowEnabled}
@@ -271,9 +263,6 @@ export default class Stack extends React.Component<Props, State> {
                   onGestureCanceled={onGestureCanceled}
                   onGestureEnd={onGestureEnd}
                   gestureResponseDistance={gestureResponseDistance}
-                  transitionSpec={transitionSpec}
-                  headerStyleInterpolator={headerStyleInterpolator}
-                  cardStyleInterpolator={cardStyleInterpolator}
                   floaingHeaderHeight={floaingHeaderHeight}
                   hasCustomHeader={header === null}
                   getPreviousRoute={getPreviousRoute}
@@ -285,6 +274,7 @@ export default class Stack extends React.Component<Props, State> {
                   onCloseRoute={onCloseRoute}
                   onTransitionStart={onTransitionStart}
                   onGoBack={onGoBack}
+                  transitionPreset={computedTransitionPreset}
                 />
               </AnimatedScreen>
             );
@@ -298,7 +288,7 @@ export default class Stack extends React.Component<Props, State> {
               navigation,
               getPreviousRoute,
               onLayout: this.handleFloatingHeaderLayout,
-              styleInterpolator: headerStyleInterpolator,
+              styleInterpolator: () => ({}),
               style: [styles.header, styles.floating],
             })
           : null}

--- a/src/views/Stack/StackItem.tsx
+++ b/src/views/Stack/StackItem.tsx
@@ -109,6 +109,15 @@ export default class StackItem extends React.PureComponent<Props> {
       renderScene,
     } = this.props;
 
+    const {
+      descriptor: {
+        options: {
+          headerStyleInterpolator: customHeaderStyleInterpolator,
+          cardStyleInterpolator: customCardStyleInterpolator,
+        },
+      },
+    } = scene;
+
     return (
       <Card
         index={index}
@@ -130,7 +139,7 @@ export default class StackItem extends React.PureComponent<Props> {
         onGestureEnd={onGestureEnd}
         gestureResponseDistance={gestureResponseDistance}
         transitionSpec={transitionSpec}
-        styleInterpolator={cardStyleInterpolator}
+        styleInterpolator={customCardStyleInterpolator || cardStyleInterpolator}
         accessibilityElementsHidden={!focused}
         importantForAccessibility={focused ? 'auto' : 'no-hide-descendants'}
         pointerEvents="box-none"
@@ -149,7 +158,8 @@ export default class StackItem extends React.PureComponent<Props> {
               scenes: [previousScene, scene],
               navigation,
               getPreviousRoute,
-              styleInterpolator: headerStyleInterpolator,
+              styleInterpolator:
+                customHeaderStyleInterpolator || headerStyleInterpolator,
               style: styles.header,
             })
           : null}

--- a/src/views/Stack/StackItem.tsx
+++ b/src/views/Stack/StackItem.tsx
@@ -9,10 +9,10 @@ import {
   Layout,
   HeaderMode,
   NavigationProp,
+  TransitionPreset,
 } from '../../types';
-import { TransitionPreset } from '../../../lib/typescript/types';
 
-type Props = {
+type Props = TransitionPreset & {
   index: number;
   active: boolean;
   focused: boolean;
@@ -48,7 +48,6 @@ type Props = {
   headerTransparent?: boolean;
   floaingHeaderHeight: number;
   hasCustomHeader: boolean;
-  transitionPreset: TransitionPreset;
 };
 
 export default class StackItem extends React.PureComponent<Props> {
@@ -94,7 +93,10 @@ export default class StackItem extends React.PureComponent<Props> {
       headerTransparent,
       renderHeader,
       renderScene,
-      transitionPreset,
+      direction,
+      transitionSpec,
+      cardStyleInterpolator,
+      headerStyleInterpolator,
     } = this.props;
 
     return (
@@ -102,7 +104,7 @@ export default class StackItem extends React.PureComponent<Props> {
         index={index}
         active={active}
         transparent={cardTransparent}
-        direction={transitionPreset.direction}
+        direction={direction}
         layout={layout}
         current={current}
         next={scene.progress.next}
@@ -117,8 +119,8 @@ export default class StackItem extends React.PureComponent<Props> {
         onGestureCanceled={onGestureCanceled}
         onGestureEnd={onGestureEnd}
         gestureResponseDistance={gestureResponseDistance}
-        transitionSpec={transitionPreset.transitionSpec}
-        styleInterpolator={transitionPreset.cardStyleInterpolator}
+        transitionSpec={transitionSpec}
+        styleInterpolator={cardStyleInterpolator}
         accessibilityElementsHidden={!focused}
         importantForAccessibility={focused ? 'auto' : 'no-hide-descendants'}
         pointerEvents="box-none"
@@ -137,7 +139,7 @@ export default class StackItem extends React.PureComponent<Props> {
               scenes: [previousScene, scene],
               navigation,
               getPreviousRoute,
-              styleInterpolator: transitionPreset.headerStyleInterpolator,
+              styleInterpolator: headerStyleInterpolator,
               style: styles.header,
             })
           : null}

--- a/src/views/Stack/StackItem.tsx
+++ b/src/views/Stack/StackItem.tsx
@@ -6,14 +6,11 @@ import Card from './Card';
 import {
   Route,
   HeaderScene,
-  GestureDirection,
   Layout,
-  TransitionSpec,
-  CardStyleInterpolator,
   HeaderMode,
   NavigationProp,
-  HeaderStyleInterpolator,
 } from '../../types';
+import { TransitionPreset } from '../../../lib/typescript/types';
 
 type Props = {
   index: number;
@@ -30,7 +27,6 @@ type Props = {
   cardShadowEnabled?: boolean;
   cardStyle?: StyleProp<ViewStyle>;
   gesturesEnabled?: boolean;
-  direction: GestureDirection;
   getPreviousRoute: (props: { route: Route }) => Route | undefined;
   renderHeader: (props: HeaderContainerProps) => React.ReactNode;
   renderScene: (props: { route: Route }) => React.ReactNode;
@@ -48,16 +44,11 @@ type Props = {
     vertical?: number;
     horizontal?: number;
   };
-  transitionSpec: {
-    open: TransitionSpec;
-    close: TransitionSpec;
-  };
-  headerStyleInterpolator: HeaderStyleInterpolator;
-  cardStyleInterpolator: CardStyleInterpolator;
   headerMode: HeaderMode;
   headerTransparent?: boolean;
   floaingHeaderHeight: number;
   hasCustomHeader: boolean;
+  transitionPreset: TransitionPreset;
 };
 
 export default class StackItem extends React.PureComponent<Props> {
@@ -87,7 +78,6 @@ export default class StackItem extends React.PureComponent<Props> {
       navigation,
       scene,
       previousScene,
-      direction,
       cardTransparent,
       cardOverlayEnabled,
       cardShadowEnabled,
@@ -97,9 +87,6 @@ export default class StackItem extends React.PureComponent<Props> {
       onGestureCanceled,
       onGestureEnd,
       gestureResponseDistance,
-      transitionSpec,
-      headerStyleInterpolator,
-      cardStyleInterpolator,
       floaingHeaderHeight,
       hasCustomHeader,
       getPreviousRoute,
@@ -107,23 +94,15 @@ export default class StackItem extends React.PureComponent<Props> {
       headerTransparent,
       renderHeader,
       renderScene,
+      transitionPreset,
     } = this.props;
-
-    const {
-      descriptor: {
-        options: {
-          headerStyleInterpolator: customHeaderStyleInterpolator,
-          cardStyleInterpolator: customCardStyleInterpolator,
-        },
-      },
-    } = scene;
 
     return (
       <Card
         index={index}
         active={active}
         transparent={cardTransparent}
-        direction={direction}
+        direction={transitionPreset.direction}
         layout={layout}
         current={current}
         next={scene.progress.next}
@@ -138,8 +117,8 @@ export default class StackItem extends React.PureComponent<Props> {
         onGestureCanceled={onGestureCanceled}
         onGestureEnd={onGestureEnd}
         gestureResponseDistance={gestureResponseDistance}
-        transitionSpec={transitionSpec}
-        styleInterpolator={customCardStyleInterpolator || cardStyleInterpolator}
+        transitionSpec={transitionPreset.transitionSpec}
+        styleInterpolator={transitionPreset.cardStyleInterpolator}
         accessibilityElementsHidden={!focused}
         importantForAccessibility={focused ? 'auto' : 'no-hide-descendants'}
         pointerEvents="box-none"
@@ -158,8 +137,7 @@ export default class StackItem extends React.PureComponent<Props> {
               scenes: [previousScene, scene],
               navigation,
               getPreviousRoute,
-              styleInterpolator:
-                customHeaderStyleInterpolator || headerStyleInterpolator,
+              styleInterpolator: transitionPreset.headerStyleInterpolator,
               style: styles.header,
             })
           : null}

--- a/src/views/Stack/StackView.tsx
+++ b/src/views/Stack/StackView.tsx
@@ -6,11 +6,6 @@ import HeaderContainer, {
   Props as HeaderContainerProps,
 } from '../Header/HeaderContainer';
 import {
-  DefaultTransition,
-  ModalSlideFromBottomIOS,
-} from '../../TransitionConfigs/TransitionPresets';
-import { forNoAnimation } from '../../TransitionConfigs/HeaderStyleInterpolators';
-import {
   NavigationProp,
   SceneDescriptor,
   NavigationConfig,
@@ -283,20 +278,9 @@ class StackView extends React.Component<Props, State> {
     const headerMode =
       mode !== 'modal' && Platform.OS === 'ios' ? 'float' : 'screen';
 
-    let transitionPreset =
-      mode === 'modal' && Platform.OS === 'ios'
-        ? ModalSlideFromBottomIOS
-        : DefaultTransition;
-
-    if (headerMode === 'screen') {
-      transitionPreset = {
-        ...transitionPreset,
-        headerStyleInterpolator: forNoAnimation,
-      };
-    }
-
     return (
       <Stack
+        mode={mode}
         getPreviousRoute={this.getPreviousRoute}
         getGesturesEnabled={this.getGesturesEnabled}
         routes={routes}
@@ -314,7 +298,6 @@ class StackView extends React.Component<Props, State> {
         headerMode={headerMode}
         navigation={navigation}
         descriptors={descriptors}
-        transitionPreset={transitionPreset}
         {...config}
       />
     );

--- a/src/views/Stack/StackView.tsx
+++ b/src/views/Stack/StackView.tsx
@@ -314,7 +314,7 @@ class StackView extends React.Component<Props, State> {
         headerMode={headerMode}
         navigation={navigation}
         descriptors={descriptors}
-        {...transitionPreset}
+        transitionPreset={transitionPreset}
         {...config}
       />
     );


### PR DESCRIPTION
As @satya164 suggested in #154, instead of passing `navigationOptions` to interpolators, they can be allowed to specify their own interpolators.

Custom interpolator, if defined, takes precedence over the one from `NavigationConfig`. The rest of the logic stays the same.