### PR TITLE
Reduce card gesture velocity impact

### DIFF
--- a/src/views/Stack/Card.tsx
+++ b/src/views/Stack/Card.tsx
@@ -253,11 +253,7 @@ export default class Card extends React.Component<Props> {
   );
   private extrapolatedPosition = add(
     this.gesture,
-    multiply(
-      this.velocity,
-      this.velocitySignum,
-      SWIPE_VELOCITY_IMPACT
-    )
+    multiply(this.velocity, this.velocitySignum, SWIPE_VELOCITY_IMPACT)
   );
 
   private exec = block([

--- a/src/views/Stack/Card.tsx
+++ b/src/views/Stack/Card.tsx
@@ -60,7 +60,7 @@ const UNSET = -1;
 const DIRECTION_VERTICAL = -1;
 const DIRECTION_HORIZONTAL = 1;
 
-const SWIPE_VELOCITY_IMPACT = 0.2;
+const SWIPE_VELOCITY_IMPACT = 0.3;
 
 /**
  * The distance of touch start from the edge of the screen where the gesture will be recognized

--- a/src/views/Stack/Card.tsx
+++ b/src/views/Stack/Card.tsx
@@ -60,7 +60,7 @@ const UNSET = -1;
 const DIRECTION_VERTICAL = -1;
 const DIRECTION_HORIZONTAL = 1;
 
-const SWIPE_VELOCITY_IMPACT = 0.01;
+const SWIPE_VELOCITY_IMPACT = 0.2;
 
 /**
  * The distance of touch start from the edge of the screen where the gesture will be recognized
@@ -254,7 +254,6 @@ export default class Card extends React.Component<Props> {
   private extrapolatedPosition = add(
     this.gesture,
     multiply(
-      this.velocity,
       this.velocity,
       this.velocitySignum,
       SWIPE_VELOCITY_IMPACT

--- a/src/views/Stack/Card.tsx
+++ b/src/views/Stack/Card.tsx
@@ -246,14 +246,9 @@ export default class Card extends React.Component<Props> {
     ]);
   };
 
-  private velocitySignum = cond(
-    this.velocity,
-    divide(abs(this.velocity), this.velocity),
-    0
-  );
   private extrapolatedPosition = add(
     this.gesture,
-    multiply(this.velocity, this.velocitySignum, SWIPE_VELOCITY_IMPACT)
+    multiply(this.velocity, SWIPE_VELOCITY_IMPACT)
   );
 
   private exec = block([


### PR DESCRIPTION
Double multiplication of gesture velocity was making the card too sensitive—reduced to 1x multiplication and increased `SWIPE_VELOCITY_IMPACT` to compensate.