### PR TITLE
feat: change single param to props object in onTransition callbacks

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -93,6 +93,10 @@ export type HeaderProps = {
   styleInterpolator: HeaderStyleInterpolator;
 };
 
+export type TransitionCallbackProps = {
+  closing: boolean;
+};
+
 export type NavigationStackOptions = HeaderOptions &
   Partial<TransitionPreset> & {
     title?: string;
@@ -107,8 +111,8 @@ export type NavigationStackOptions = HeaderOptions &
       vertical?: number;
       horizontal?: number;
     };
-    onTransitionStart?: (closing: boolean) => void;
-    onTransitionEnd?: (closing: boolean) => void;
+    onTransitionStart?: (props: TransitionCallbackProps) => void;
+    onTransitionEnd?: (props: TransitionCallbackProps) => void;
   };
 
 export type NavigationStackConfig = {

--- a/src/views/Stack/Stack.tsx
+++ b/src/views/Stack/Stack.tsx
@@ -263,7 +263,7 @@ export default class Stack extends React.Component<Props, State> {
 
     descriptor &&
       descriptor.options.onTransitionStart &&
-      descriptor.options.onTransitionStart(closing);
+      descriptor.options.onTransitionStart({ closing });
   };
 
   private handleTransitionEnd = (
@@ -274,7 +274,7 @@ export default class Stack extends React.Component<Props, State> {
 
     descriptor &&
       descriptor.options.onTransitionEnd &&
-      descriptor.options.onTransitionEnd(closing);
+      descriptor.options.onTransitionEnd({ closing });
   };
 
   render() {


### PR DESCRIPTION
As suggested by @satya164, I am submitting another PR changing single argument `closing` to an extendable properties object.