### PR TITLE
feat: add sticky keyboard mode

### DIFF
--- a/src/navigators/createStackNavigator.tsx
+++ b/src/navigators/createStackNavigator.tsx
@@ -27,13 +27,15 @@ function createStackNavigator(
 ) {
   const router = StackRouter(routeConfigMap, stackConfig);
 
-  if (stackConfig.disableKeyboardHandling || Platform.OS === 'web') {
+  if (stackConfig.keyboardHandling === 'disabled' || Platform.OS === 'web') {
     return createNavigator(StackView, router, stackConfig);
   }
 
   return createNavigator(
     navigatorProps => (
-      <KeyboardManager>
+      <KeyboardManager
+        stickyKeyboard={stackConfig.keyboardHandling === 'sticky'}
+      >
         {props => <StackView {...props} {...navigatorProps} />}
       </KeyboardManager>
     ),

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -115,10 +115,12 @@ export type NavigationStackOptions = HeaderOptions &
     onTransitionEnd?: (props: TransitionCallbackProps) => void;
   };
 
+export type KeyboardHandling = 'disabled' | 'sticky' | 'default';
+
 export type NavigationStackConfig = {
   mode?: 'card' | 'modal';
   headerMode?: HeaderMode;
-  disableKeyboardHandling?: boolean;
+  keyboardHandling?: KeyboardHandling;
 };
 
 export type SceneDescriptor = {

--- a/src/views/KeyboardManager.tsx
+++ b/src/views/KeyboardManager.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { TextInput, Keyboard } from 'react-native';
 
 type Props = {
+  stickyKeyboard: boolean;
   children: (props: {
     onPageChangeStart: () => void;
     onPageChangeConfirm: () => void;
@@ -15,10 +16,14 @@ export default class KeyboardManager extends React.Component<Props> {
   private previouslyFocusedTextInput: number | null = null;
 
   private handlePageChangeStart = () => {
-    const input = TextInput.State.currentlyFocusedField();
+    const input: number | null =
+      TextInput.State.currentlyFocusedField() ||
+      (this.props.stickyKeyboard ? this.previouslyFocusedTextInput : null);
 
     // When a page change begins, blur the currently focused input
-    TextInput.State.blurTextInput(input);
+    if (input !== null) {
+      TextInput.State.blurTextInput(input);
+    }
 
     // Store the id of this input so we can refocus it if change was cancelled
     this.previouslyFocusedTextInput = input;
@@ -39,7 +44,9 @@ export default class KeyboardManager extends React.Component<Props> {
       TextInput.State.focusTextInput(input);
     }
 
-    this.previouslyFocusedTextInput = null;
+    if (!this.props.stickyKeyboard) {
+      this.previouslyFocusedTextInput = null;
+    }
   };
 
   render() {


### PR DESCRIPTION
I was playing with what I believed was a bug with keyboard behavior. When dismissing a screen, if the operation is canceled and screen stays on top, the keyboard (which happens via text focus) reopens. But due to its logic, doing something like a double cancel dismisses the keyboard in a way it won't reopen.

I realized that it is probably an intended behavior (the experience is quite intuitive), but there still exists a need for different keyboard behavior especially a one that makes keyboard stay open all the time.

To achieve that, I changed `disableKeyboardHandling` param to an enum which handles choice between default, disabled and sticky mode keyboard.