### PR TITLE
Fixed didFocus events are no longer triggered in react-navigation/core (alpha.7)

### DIFF
--- a/src/views/Stack/StackView.tsx
+++ b/src/views/Stack/StackView.tsx
@@ -231,9 +231,11 @@ class StackView extends React.Component<Props, State> {
     return <HeaderContainer {...props} />;
   };
 
-  private handleTransitionComplete = () => {
+  private handleTransitionComplete = ({ route }: { route: Route }) => {
     // TODO: remove when the new event system lands
-    this.props.navigation.dispatch(StackActions.completeTransition());
+    this.props.navigation.dispatch(
+      StackActions.completeTransition({ toChildKey: route.key })
+    );
   };
 
   private handleGoBack = ({ route }: { route: Route }) => {
@@ -243,7 +245,7 @@ class StackView extends React.Component<Props, State> {
   };
 
   private handleOpenRoute = ({ route }: { route: Route }) => {
-    this.handleTransitionComplete();
+    this.handleTransitionComplete({ route });
     this.setState(state => ({
       routes: state.replacing.length
         ? state.routes.filter(r => !state.replacing.includes(r.key))
@@ -255,7 +257,7 @@ class StackView extends React.Component<Props, State> {
   };
 
   private handleCloseRoute = ({ route }: { route: Route }) => {
-    this.handleTransitionComplete();
+    this.handleTransitionComplete({ route });
 
     // This event will trigger when the animation for closing the route ends
     // In this case, we need to clean up any state tracking the route and pop it immediately

--- a/src/views/Stack/StackView.tsx
+++ b/src/views/Stack/StackView.tsx
@@ -257,17 +257,21 @@ class StackView extends React.Component<Props, State> {
   };
 
   private handleCloseRoute = ({ route }: { route: Route }) => {
-    this.handleTransitionComplete({ route });
-
     // This event will trigger when the animation for closing the route ends
     // In this case, we need to clean up any state tracking the route and pop it immediately
 
     // @ts-ignore
-    this.setState(state => ({
-      routes: state.routes.filter(r => r.key !== route.key),
-      opening: state.opening.filter(key => key !== route.key),
-      closing: state.closing.filter(key => key !== route.key),
-    }));
+    this.setState(
+      state => ({
+        routes: state.routes.filter(r => r.key !== route.key),
+        opening: state.opening.filter(key => key !== route.key),
+        closing: state.closing.filter(key => key !== route.key),
+      }),
+      () => {
+        const lastRoute = this.state.routes[this.state.routes.length - 1];
+        this.handleTransitionComplete({ route: lastRoute });
+      }
+    );
   };
 
   render() {


### PR DESCRIPTION
The `didFocus` event was no longer being triggered in the core event-system. This bugfix restores the `toChildKey` prop in the completeTransition action and fixes the `didFocus` event