### PR TITLE
feat: support multiple tint colors for `HeaderSegment`

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -66,6 +66,8 @@ export type HeaderOptions = {
   headerTitleStyle?: StyleProp<TextStyle>;
   headerTitleContainerStyle?: StyleProp<ViewStyle>;
   headerTintColor?: string;
+  headerLeftTintColor?: string;
+  headerRightTintColor?: string;
   headerTitleAllowFontScaling?: boolean;
   headerBackAllowFontScaling?: boolean;
   headerBackTitle?: string;

--- a/src/views/Header/HeaderSegment.tsx
+++ b/src/views/Header/HeaderSegment.tsx
@@ -148,6 +148,8 @@ export default class HeaderSegment extends React.Component<Props, State> {
       headerStatusBarHeight = getStatusBarHeight(layout.width > layout.height),
       headerTransparent,
       headerTintColor,
+      headerLeftTintColor,
+      headerRightTintColor,
       headerBackground,
       headerRight: right,
       headerBackImage: backImage,
@@ -287,7 +289,7 @@ export default class HeaderSegment extends React.Component<Props, State> {
           onLabelLayout: this.handleLeftLabelLayout,
           screenLayout: layout,
           titleLayout,
-          tintColor: headerTintColor,
+          tintColor: headerLeftTintColor || headerTintColor,
           canGoBack: Boolean(onGoBack),
         })
       : null;
@@ -345,7 +347,7 @@ export default class HeaderSegment extends React.Component<Props, State> {
                 pointerEvents="box-none"
                 style={[styles.right, rightButtonStyle, rightContainerStyle]}
               >
-                {right({ tintColor: headerTintColor })}
+                {right({ tintColor: headerRightTintColor || headerTintColor })}
               </Animated.View>
             ) : null}
           </View>


### PR DESCRIPTION
* adds `headerLeftTintColor` and `headerRightTintColor` options

Fixes https://github.com/react-navigation/stack/issues/197