### PR TITLE
feat: change header height

### DIFF
--- a/src/navigators/__tests__/__snapshots__/NestedNavigator.test.tsx.snap
+++ b/src/navigators/__tests__/__snapshots__/NestedNavigator.test.tsx.snap
@@ -349,6 +349,9 @@ Array [
                           Object {
                             "opacity": undefined,
                           },
+                          Object {
+                            "height": undefined,
+                          },
                         ]
                       }
                     >
@@ -487,6 +490,9 @@ Array [
             },
             Object {
               "opacity": undefined,
+            },
+            Object {
+              "height": undefined,
             },
           ]
         }

--- a/src/navigators/__tests__/__snapshots__/StackNavigator.test.tsx.snap
+++ b/src/navigators/__tests__/__snapshots__/StackNavigator.test.tsx.snap
@@ -198,6 +198,9 @@ Array [
             Object {
               "opacity": undefined,
             },
+            Object {
+              "height": undefined,
+            },
           ]
         }
       >
@@ -515,6 +518,9 @@ Array [
             },
             Object {
               "opacity": undefined,
+            },
+            Object {
+              "height": undefined,
             },
           ]
         }

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -82,6 +82,7 @@ export type HeaderOptions = {
   headerPressColorAndroid?: string;
   headerBackground?: () => React.ReactNode;
   headerStyle?: StyleProp<ViewStyle>;
+  headerHeight?: number;
   headerStatusBarHeight?: number;
   headerTransparent?: boolean;
 };

--- a/src/views/Header/HeaderSegment.tsx
+++ b/src/views/Header/HeaderSegment.tsx
@@ -165,6 +165,7 @@ export default class HeaderSegment extends React.Component<Props, State> {
       headerRightContainerStyle: rightContainerStyle,
       headerTitleContainerStyle: titleContainerStyle,
       headerStyle: customHeaderStyle,
+      headerHeight,
       styleInterpolator,
     } = this.props;
 
@@ -298,7 +299,11 @@ export default class HeaderSegment extends React.Component<Props, State> {
       <React.Fragment>
         <Animated.View
           pointerEvents="none"
-          style={[StyleSheet.absoluteFill, backgroundStyle]}
+          style={[
+            StyleSheet.absoluteFill,
+            backgroundStyle,
+            { height: headerHeight },
+          ]}
         >
           {headerBackground ? (
             headerBackground()


### PR DESCRIPTION
Often times we want to change the header height on a per screen basis. However, a limitation exists with the current method of changing the height via `headerStyle`. Using `headerStyle.height` results in a header that centers everything vertically. A common pattern in iOS is to have the back button with what essentially amounts to a `top: 0` value.

This PR adds the `headerHeight` option to circumvent this. I'm undecided on if the new option should be `headerHeight` or `headerBackgroundHeight`. The latter is _technically_ more accurate, but also more words to type. Open to suggestions!

### Examples with a vertically stacked `headerTitle` element
![howItIsToday](https://user-images.githubusercontent.com/4613917/63981973-fca27380-ca75-11e9-923b-5ff4257420af.png)
**No styling applied**

![headerStyle-height](https://user-images.githubusercontent.com/4613917/63982023-2a87b800-ca76-11e9-9425-1d1591e25f25.png)
**`headerStyle: { height: 120 }` results in vertically centering everything in the header, including the back button.**

![headerHeight](https://user-images.githubusercontent.com/4613917/63982049-4428ff80-ca76-11e9-9d07-99bf4e914ba0.png)
**`headerHeight: 120` leaves the back button in its original position while adjusting the height of the header segment.**

### Example code usage
```javascript
static navigationOptions = {
  headerTitle: () => (
    <View
      style={{
        alignItems: 'center',
        justifyContent: 'center',
        marginTop: 30,
      }}
    >
      <View
        style={{
          width: 40,
          height: 40,
          borderRadius: 100,
          backgroundColor: '#ff0066',
        }}
      />
      <Text style={{ fontSize: 12 }}>DisplayName</Text>
    </View>
  ),
  headerTintColor: '#fff',
  headerHeight: 120,  // new option
  headerStyle: {
    backgroundColor: '#3388ff'
  },
}
```