### PR TITLE
feat: if cardStyle has flexed specified, set the same value on PointerEventsView

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -29,6 +29,7 @@ import {
   HeaderBackgroundDefault,
   HeaderBackgroundFade,
 } from './src/HeaderBackgrounds';
+import DragLimitedToModal from './src/DragLimitedToModal';
 
 // Comment the following two lines to stop using react-native-screens
 import { useScreens } from 'react-native-screens';
@@ -90,6 +91,11 @@ const data = [
     component: HeaderBackgroundFade,
     title: 'Header background (fade transition)',
     routeName: 'HeaderBackgroundFade',
+  },
+  {
+    component: DragLimitedToModal,
+    title: 'Drag limited to modal',
+    routeName: 'DragLimitedToModal',
   },
 ];
 

--- a/example/src/DragLimitedToModal.js
+++ b/example/src/DragLimitedToModal.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { View, Text, StyleSheet, Dimensions } from 'react-native';
+import Animated from 'react-native-reanimated';
+
+const HEIGHT = Dimensions.get('screen').height;
+
+const { interpolate } = Animated;
+
+const DragLimitedToModal = () => (
+  <View style={styles.modal}>
+    <Text style={styles.text}>Adjusts to the size of text</Text>
+  </View>
+);
+
+DragLimitedToModal.navigationOptions = {
+  gestureDirection: 'vertical',
+  gestureResponseDistance: { vertical: HEIGHT },
+  cardTransparent: true,
+  cardStyleInterpolator: ({ current }) => {
+    const translateY = interpolate(current.progress, {
+      inputRange: [0, 1],
+      outputRange: [HEIGHT, 0],
+    });
+
+    return {
+      cardStyle: {
+        transform: [{ translateY }],
+        flex: undefined,
+      },
+      containerStyle: {
+        alignItems: 'center',
+        justifyContent: 'center',
+      },
+    };
+  },
+};
+
+const styles = StyleSheet.create({
+  modal: {
+    padding: 30,
+    borderRadius: 15,
+    backgroundColor: '#000',
+  },
+  text: {
+    fontSize: 18,
+    color: '#fff',
+  },
+});
+
+export default DragLimitedToModal;

--- a/src/navigators/__tests__/__snapshots__/NestedNavigator.test.tsx.snap
+++ b/src/navigators/__tests__/__snapshots__/NestedNavigator.test.tsx.snap
@@ -146,6 +146,7 @@ Array [
                       "flex": 1,
                       "overflow": "hidden",
                     },
+                    null,
                     Object {
                       "backgroundColor": "#eee",
                     },
@@ -297,6 +298,7 @@ Array [
                                     "flex": 1,
                                     "overflow": "hidden",
                                   },
+                                  null,
                                   Object {
                                     "backgroundColor": "#eee",
                                   },

--- a/src/navigators/__tests__/__snapshots__/StackNavigator.test.tsx.snap
+++ b/src/navigators/__tests__/__snapshots__/StackNavigator.test.tsx.snap
@@ -146,6 +146,7 @@ Array [
                       "flex": 1,
                       "overflow": "hidden",
                     },
+                    null,
                     Object {
                       "backgroundColor": "#eee",
                     },
@@ -464,6 +465,7 @@ Array [
                       "flex": 1,
                       "overflow": "hidden",
                     },
+                    null,
                     Object {
                       "backgroundColor": "#eee",
                     },

--- a/src/views/Stack/Card.tsx
+++ b/src/views/Stack/Card.tsx
@@ -638,10 +638,8 @@ export default class Card extends React.Component<Props> {
         : this.handleGestureEventHorizontal
       : undefined;
 
-    const overrideFlex =
-      cardStyle && cardStyle.hasOwnProperty('flex')
-        ? { flex: cardStyle.flex }
-        : {};
+    const overrideFlex = cardStyle &&
+      cardStyle.hasOwnProperty('flex') && { flex: cardStyle.flex };
 
     return (
       <StackGestureContext.Provider value={this.gestureRef}>

--- a/src/views/Stack/Card.tsx
+++ b/src/views/Stack/Card.tsx
@@ -638,8 +638,10 @@ export default class Card extends React.Component<Props> {
         : this.handleGestureEventHorizontal
       : undefined;
 
-    const overrideFlex = cardStyle &&
-      cardStyle.hasOwnProperty('flex') && { flex: cardStyle.flex };
+    const overrideFlex =
+      cardStyle && cardStyle.hasOwnProperty('flex')
+        ? { flex: cardStyle.flex }
+        : undefined;
 
     return (
       <StackGestureContext.Provider value={this.gestureRef}>

--- a/src/views/Stack/Card.tsx
+++ b/src/views/Stack/Card.tsx
@@ -638,10 +638,16 @@ export default class Card extends React.Component<Props> {
         : this.handleGestureEventHorizontal
       : undefined;
 
-    const overrideFlex =
-      cardStyle && cardStyle.hasOwnProperty('flex')
-        ? { flex: cardStyle.flex }
-        : undefined;
+    let overrideFlex = null;
+    if (Array.isArray(cardStyle)) {
+      cardStyle.forEach((style: any) => {
+        if (style.hasOwnProperty('flex')) {
+          overrideFlex = { flex: style.flex };
+        }
+      });
+    } else if (cardStyle && cardStyle.hasOwnProperty('flex')) {
+      overrideFlex = { flex: cardStyle.flex };
+    }
 
     return (
       <StackGestureContext.Provider value={this.gestureRef}>

--- a/src/views/Stack/Card.tsx
+++ b/src/views/Stack/Card.tsx
@@ -640,7 +640,7 @@ export default class Card extends React.Component<Props> {
 
     let overrideFlex = null;
     if (cardStyle) {
-      const style: any = StyleSheet.flatten(cardStyle);
+      const style = StyleSheet.flatten(cardStyle) as ViewStyle;
       if (style.hasOwnProperty('flex')) {
         overrideFlex = { flex: style.flex };
       }

--- a/src/views/Stack/Card.tsx
+++ b/src/views/Stack/Card.tsx
@@ -638,6 +638,11 @@ export default class Card extends React.Component<Props> {
         : this.handleGestureEventHorizontal
       : undefined;
 
+    const overrideFlex =
+      cardStyle && cardStyle.hasOwnProperty('flex')
+        ? { flex: cardStyle.flex }
+        : {};
+
     return (
       <StackGestureContext.Provider value={this.gestureRef}>
         <View pointerEvents="box-none" {...rest}>
@@ -681,6 +686,7 @@ export default class Card extends React.Component<Props> {
                   progress={this.props.current}
                   style={[
                     styles.content,
+                    overrideFlex,
                     transparent ? styles.transparent : styles.opaque,
                     contentStyle,
                   ]}

--- a/src/views/Stack/Card.tsx
+++ b/src/views/Stack/Card.tsx
@@ -639,14 +639,11 @@ export default class Card extends React.Component<Props> {
       : undefined;
 
     let overrideFlex = null;
-    if (Array.isArray(cardStyle)) {
-      cardStyle.forEach((style: any) => {
-        if (style.hasOwnProperty('flex')) {
-          overrideFlex = { flex: style.flex };
-        }
-      });
-    } else if (cardStyle && cardStyle.hasOwnProperty('flex')) {
-      overrideFlex = { flex: cardStyle.flex };
+    if (cardStyle) {
+      const style: any = StyleSheet.flatten(cardStyle);
+      if (style.hasOwnProperty('flex')) {
+        overrideFlex = { flex: style.flex };
+      }
     }
 
     return (


### PR DESCRIPTION
### Problem

I was trying to achieve the following effect:

The transition used to dismiss modal by dragging it down, should only respond to gesture on the modal itself, not any background.

I found out that I can achieve it by using the way stack hierarchy works:
The screen component is wrapped by 'card' component which is wrapped in a pan gesture handler which is then wrapped in 'container' component.

### Obstacles

If I specified `height` and `width` for the card component, it worked perfectly. However, there was still a problem with dynamically sized modals, since `flex: 1` is present in container, card and another internal component wrapping the screen which is called `<PointerEventsView>`.

### Solution

The least invasive way to solve it which allows for dynamically sized modals and doesn't require API changes would be to copy the `flex: 1` style from `card` to `<PointerEventsView>`.