### PR TITLE
fix: remove unused prop in HeaderBackButton

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -192,9 +192,7 @@ export type HeaderBackButtonProps = {
   backTitleVisible?: boolean;
   allowFontScaling?: boolean;
   titleStyle?: StyleProp<TextStyle>;
-  layoutPreset: HeaderLayoutPreset;
   width?: number;
-  scene: Scene;
 };
 
 export type SceneInterpolatorProps = {

--- a/src/views/Header/Header.tsx
+++ b/src/views/Header/Header.tsx
@@ -282,9 +282,7 @@ class Header extends React.PureComponent<Props, State> {
         backTitleVisible={this.props.backTitleVisible}
         allowFontScaling={options.headerBackAllowFontScaling}
         titleStyle={options.headerBackTitleStyle}
-        layoutPreset={this.props.layoutPreset}
         width={width}
-        scene={props.scene}
       />
     );
   };
@@ -326,9 +324,7 @@ class Header extends React.PureComponent<Props, State> {
         title={backButtonTitle}
         truncatedTitle={truncatedBackButtonTitle}
         titleStyle={options.headerBackTitleStyle}
-        layoutPreset={this.props.layoutPreset}
         width={width}
-        scene={props.scene}
       />
     );
   };


### PR DESCRIPTION
Hello!
Following the conversation of https://github.com/flow-typed/flow-typed/issues/3574 I'm opening this PR in order remove some props that seems to be unused in the `HeaderBackButton` component. 

Sorry if I missed something, I'm not really familiar with the react-navigation codebase.
Thanks in advance