### PR TITLE
Display Header with Flexbox

### DIFF
--- a/src/navigators/__tests__/__snapshots__/NestedNavigator.test.tsx.snap
+++ b/src/navigators/__tests__/__snapshots__/NestedNavigator.test.tsx.snap
@@ -432,11 +432,11 @@ Array [
                             pointerEvents="box-none"
                             style={
                               Object {
-                                "alignItems": "center",
+                                "alignItems": "stretch",
                                 "flex": 1,
                                 "flexDirection": "row",
                                 "justifyContent": "center",
-                                "paddingHorizontal": 4,
+                                "paddingHorizontal": 0,
                               }
                             }
                           >
@@ -573,11 +573,11 @@ Array [
           pointerEvents="box-none"
           style={
             Object {
-              "alignItems": "center",
+              "alignItems": "stretch",
               "flex": 1,
               "flexDirection": "row",
               "justifyContent": "center",
-              "paddingHorizontal": 4,
+              "paddingHorizontal": 0,
             }
           }
         >

--- a/src/navigators/__tests__/__snapshots__/StackNavigator.test.tsx.snap
+++ b/src/navigators/__tests__/__snapshots__/StackNavigator.test.tsx.snap
@@ -267,11 +267,11 @@ Array [
           pointerEvents="box-none"
           style={
             Object {
-              "alignItems": "center",
+              "alignItems": "stretch",
               "flex": 1,
               "flexDirection": "row",
               "justifyContent": "center",
-              "paddingHorizontal": 4,
+              "paddingHorizontal": 0,
             }
           }
         >
@@ -315,11 +315,7 @@ Array [
               Array [
                 Object {
                   "alignItems": "flex-end",
-                  "bottom": 0,
                   "justifyContent": "center",
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
                 },
                 Object {
                   "opacity": undefined,
@@ -604,11 +600,11 @@ Array [
           pointerEvents="box-none"
           style={
             Object {
-              "alignItems": "center",
+              "alignItems": "stretch",
               "flex": 1,
               "flexDirection": "row",
               "justifyContent": "center",
-              "paddingHorizontal": 4,
+              "paddingHorizontal": 0,
             }
           }
         >

--- a/src/views/Header/HeaderSegment.tsx
+++ b/src/views/Header/HeaderSegment.tsx
@@ -329,10 +329,6 @@ export default class HeaderSegment extends React.Component<Props, State> {
             <Animated.View
               pointerEvents="box-none"
               style={[
-                Platform.select({
-                  ios: null,
-                  default: { paddingLeft: leftButton ? 0 : 16 },
-                }),
                 styles.title,
                 titleStyle,
                 titleContainerStyle,
@@ -369,7 +365,7 @@ export default class HeaderSegment extends React.Component<Props, State> {
 const styles = StyleSheet.create({
   content: {
     flex: 1,
-    paddingHorizontal: 4,
+    paddingHorizontal: 0,
     flexDirection: 'row',
     alignItems: 'stretch',
     justifyContent: 'center',
@@ -386,6 +382,7 @@ const styles = StyleSheet.create({
     ios: {},
     default: { 
       flex: 1,
+      paddingLeft: 16,
       justifyContent: 'center',
     },
   }),

--- a/src/views/Header/HeaderSegment.tsx
+++ b/src/views/Header/HeaderSegment.tsx
@@ -329,6 +329,10 @@ export default class HeaderSegment extends React.Component<Props, State> {
             <Animated.View
               pointerEvents="box-none"
               style={[
+                Platform.select({
+                  ios: null,
+                  default: { paddingLeft: leftButton ? 20 : 16 },
+                }),
                 styles.title,
                 titleStyle,
                 titleContainerStyle,
@@ -380,9 +384,8 @@ const styles = StyleSheet.create({
   },
   title: Platform.select({
     ios: {},
-    default: { 
+    default: {
       flex: 1,
-      paddingLeft: 16,
       justifyContent: 'center',
     },
   }),

--- a/src/views/Header/HeaderSegment.tsx
+++ b/src/views/Header/HeaderSegment.tsx
@@ -331,7 +331,7 @@ export default class HeaderSegment extends React.Component<Props, State> {
               style={[
                 Platform.select({
                   ios: null,
-                  default: { left: leftButton ? 72 : 16 },
+                  default: { paddingLeft: leftButton ? 0 : 16 },
                 }),
                 styles.title,
                 titleStyle,
@@ -371,27 +371,22 @@ const styles = StyleSheet.create({
     flex: 1,
     paddingHorizontal: 4,
     flexDirection: 'row',
-    alignItems: 'center',
+    alignItems: 'stretch',
     justifyContent: 'center',
   },
   left: {
-    position: 'absolute',
-    left: 0,
-    top: 0,
-    bottom: 0,
     justifyContent: 'center',
     alignItems: 'flex-start',
   },
   right: {
-    position: 'absolute',
-    right: 0,
-    top: 0,
-    bottom: 0,
     justifyContent: 'center',
     alignItems: 'flex-end',
   },
   title: Platform.select({
     ios: {},
-    default: { position: 'absolute' },
+    default: { 
+      flex: 1,
+      justifyContent: 'center',
+    },
   }),
 });


### PR DESCRIPTION
Remove the use of `position: absolute` and use `Flexbox` instead.

I have no idea why it used to be *absolute positioned* but that made it hard to easily modify, as proven by [Issue#196](https://github.com/react-navigation/stack/issues/196).

This PR should fix this kind of issue, as such:
```
class HomeScreen extends React.Component {
  static navigationOptions = {
    title: 'Home',
    headerTitleContainerStyle: {
      alignItems: 'center', // center horizontally
    },
  };

  render() {
    return (
      <View>
        <Text>Hello World!</Text>
      </View>
    );
  }
}
```

*I use only Android, I couldn't test on iOS but it **should** work the same way*
