### PR TITLE
feat: expose stack transition values via context

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -29,6 +29,7 @@ import {
   HeaderBackgroundFade,
 } from './src/HeaderBackgrounds';
 import DragLimitedToModal from './src/DragLimitedToModal';
+import StackAnimationConsumerStack from './src/StackAnimationConsumerStack';
 
 // Comment the following two lines to stop using react-native-screens
 // eslint-disable-next-line import/no-unresolved
@@ -108,6 +109,11 @@ const data: Item[] = [
     component: DragLimitedToModal,
     title: 'Drag limited to modal',
     routeName: 'DragLimitedToModal',
+  },
+  {
+    component: StackAnimationConsumerStack,
+    title: 'Stack animation consumer stack',
+    routeName: 'StackAnimationConsumerStack',
   },
 ];
 

--- a/example/src/StackAnimationConsumerStack.tsx
+++ b/example/src/StackAnimationConsumerStack.tsx
@@ -6,6 +6,7 @@ import {
   NavigationStackScreenProps,
   StackAnimationProgressContext,
   StackAnimationIsSwipingContext,
+  StackAnimationIsClosingContext,
 } from 'react-navigation-stack';
 
 const ListScreen = (props: NavigationStackScreenProps) => (
@@ -52,29 +53,45 @@ const AnotherScreen = () => (
 );
 
 const YetAnotherScreen = () => (
-  <StackAnimationIsSwipingContext.Consumer>
-    {isSwiping => {
-      const opacity = Animated.interpolate(isSwiping, {
-        inputRange: [0, 1],
-        outputRange: [1, 0],
-      });
-
-      return (
-        <View
+  <View
+    style={{
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: 'papayawhip',
+    }}
+  >
+    <StackAnimationIsSwipingContext.Consumer>
+      {isSwiping => (
+        <Animated.Text
           style={{
-            flex: 1,
-            justifyContent: 'center',
-            alignItems: 'center',
-            backgroundColor: 'cornflowerblue',
+            fontSize: 24,
+            opacity: Animated.interpolate(isSwiping, {
+              inputRange: [0, 1],
+              outputRange: [1, 0],
+            }),
           }}
         >
-          <Animated.Text style={{ fontSize: 24, opacity }}>
-            Disappears on swipe
-          </Animated.Text>
-        </View>
-      );
-    }}
-  </StackAnimationIsSwipingContext.Consumer>
+          Disappears when swiping
+        </Animated.Text>
+      )}
+    </StackAnimationIsSwipingContext.Consumer>
+    <StackAnimationIsClosingContext.Consumer>
+      {isClosing => (
+        <Animated.Text
+          style={{
+            fontSize: 24,
+            opacity: Animated.interpolate(isClosing, {
+              inputRange: [0, 1],
+              outputRange: [1, 0],
+            }),
+          }}
+        >
+          Disappears only when closing
+        </Animated.Text>
+      )}
+    </StackAnimationIsClosingContext.Consumer>
+  </View>
 );
 
 export default createStackNavigator(

--- a/example/src/StackAnimationConsumerStack.tsx
+++ b/example/src/StackAnimationConsumerStack.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { Button, View } from 'react-native';
+import Animated from 'react-native-reanimated';
+import {
+  createStackNavigator,
+  NavigationStackScreenProps,
+  StackAnimationProgressContext,
+  StackAnimationIsSwipingContext,
+} from 'react-navigation-stack';
+
+const ListScreen = (props: NavigationStackScreenProps) => (
+  <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+    <Button
+      title="Push to another screen"
+      onPress={() => props.navigation.push('Another')}
+    />
+    <Button
+      title="Push to yet another screen"
+      onPress={() => props.navigation.push('YetAnother')}
+    />
+    <Button
+      title="Go back to all examples"
+      onPress={() => props.navigation.navigate('Home')}
+    />
+  </View>
+);
+
+const AnotherScreen = () => (
+  <StackAnimationProgressContext.Consumer>
+    {progress => {
+      const fontSize = Animated.interpolate(progress.current, {
+        inputRange: [0, 1],
+        outputRange: [8, 32],
+      });
+
+      return (
+        <View
+          style={{
+            flex: 1,
+            justifyContent: 'center',
+            alignItems: 'center',
+            backgroundColor: 'honeydew',
+          }}
+        >
+          <Animated.Text style={{ fontSize, opacity: progress.current }}>
+            Animates on progress
+          </Animated.Text>
+        </View>
+      );
+    }}
+  </StackAnimationProgressContext.Consumer>
+);
+
+const YetAnotherScreen = () => (
+  <StackAnimationIsSwipingContext.Consumer>
+    {isSwiping => {
+      const opacity = Animated.interpolate(isSwiping, {
+        inputRange: [0, 1],
+        outputRange: [1, 0],
+      });
+
+      return (
+        <View
+          style={{
+            flex: 1,
+            justifyContent: 'center',
+            alignItems: 'center',
+            backgroundColor: 'cornflowerblue',
+          }}
+        >
+          <Animated.Text style={{ fontSize: 24, opacity }}>
+            Disappears on swipe
+          </Animated.Text>
+        </View>
+      );
+    }}
+  </StackAnimationIsSwipingContext.Consumer>
+);
+
+export default createStackNavigator(
+  {
+    List: ListScreen,
+    Another: AnotherScreen,
+    YetAnother: YetAnotherScreen,
+  },
+  { initialRouteName: 'List' }
+);

--- a/example/src/StackAnimationConsumerStack.tsx
+++ b/example/src/StackAnimationConsumerStack.tsx
@@ -28,7 +28,7 @@ const ListScreen = (props: NavigationStackScreenProps) => (
 const AnotherScreen = () => (
   <StackAnimationProgressContext.Consumer>
     {progress => {
-      const fontSize = Animated.interpolate(progress.current, {
+      const fontSize = Animated.interpolate(progress, {
         inputRange: [0, 1],
         outputRange: [8, 32],
       });
@@ -42,7 +42,7 @@ const AnotherScreen = () => (
             backgroundColor: 'honeydew',
           }}
         >
-          <Animated.Text style={{ fontSize, opacity: progress.current }}>
+          <Animated.Text style={{ fontSize, opacity: progress }}>
             Animates on progress
           </Animated.Text>
         </View>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,11 +37,14 @@ export {
  */
 export { default as StackGestureContext } from './utils/StackGestureContext';
 export {
+  default as StackAnimationProgressContext,
+} from './utils/StackAnimationProgressContext';
+export {
   default as StackAnimationIsSwipingContext,
 } from './utils/StackAnimationIsSwipingContext';
 export {
-  default as StackAnimationProgressContext,
-} from './utils/StackAnimationProgressContext';
+  default as StackAnimationIsClosingContext,
+} from './utils/StackAnimationIsClosingContext';
 
 /**
  * Types

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,11 +35,13 @@ export {
 /**
  * Utilities
  */
-
 export { default as StackGestureContext } from './utils/StackGestureContext';
 export {
   default as StackAnimationIsSwipingContext,
 } from './utils/StackAnimationIsSwipingContext';
+export {
+  default as StackAnimationProgressContext,
+} from './utils/StackAnimationProgressContext';
 
 /**
  * Types

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,6 +37,9 @@ export {
  */
 
 export { default as StackGestureContext } from './utils/StackGestureContext';
+export {
+  default as StackAnimationIsSwipingContext,
+} from './utils/StackAnimationIsSwipingContext';
 
 /**
  * Types

--- a/src/utils/StackAnimationIsClosingContext.tsx
+++ b/src/utils/StackAnimationIsClosingContext.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import Animated from 'react-native-reanimated';
+
+export default React.createContext<Animated.Node<0 | 1>>(new Animated.Value(0));

--- a/src/utils/StackAnimationIsSwipingContext.tsx
+++ b/src/utils/StackAnimationIsSwipingContext.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import Animated from 'react-native-reanimated';
+
+export default React.createContext<Animated.Node<0 | 1> | undefined>(undefined);

--- a/src/utils/StackAnimationIsSwipingContext.tsx
+++ b/src/utils/StackAnimationIsSwipingContext.tsx
@@ -1,4 +1,4 @@
 import * as React from 'react';
 import Animated from 'react-native-reanimated';
 
-export default React.createContext<Animated.Node<0 | 1> | undefined>(undefined);
+export default React.createContext<Animated.Node<0 | 1>>(new Animated.Value(0));

--- a/src/utils/StackAnimationProgressContext.tsx
+++ b/src/utils/StackAnimationProgressContext.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import Animated from 'react-native-reanimated';
+
+export default React.createContext<
+  { [key: string]: Animated.Node<number> } | undefined
+>(undefined);

--- a/src/utils/StackAnimationProgressContext.tsx
+++ b/src/utils/StackAnimationProgressContext.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import Animated from 'react-native-reanimated';
 
-export default React.createContext<
-  { [key: string]: Animated.Node<number> } | undefined
->(undefined);
+type Progress = {
+  current: Animated.Value<number>;
+  next?: Animated.Value<number>;
+};
+
+export default React.createContext<Progress>({
+  current: new Animated.Value(0),
+  next: undefined,
+});

--- a/src/utils/StackAnimationProgressContext.tsx
+++ b/src/utils/StackAnimationProgressContext.tsx
@@ -1,12 +1,6 @@
 import * as React from 'react';
 import Animated from 'react-native-reanimated';
 
-type Progress = {
-  current: Animated.Value<number>;
-  next?: Animated.Value<number>;
-};
-
-export default React.createContext<Progress>({
-  current: new Animated.Value(0),
-  next: undefined,
-});
+export default React.createContext<Animated.Value<number>>(
+  new Animated.Value(0)
+);

--- a/src/views/Stack/Card.tsx
+++ b/src/views/Stack/Card.tsx
@@ -25,6 +25,7 @@ import {
 import memoize from '../../utils/memoize';
 import StackGestureContext from '../../utils/StackGestureContext';
 import PointerEventsView from './PointerEventsView';
+import StackAnimationProgressContext from '../../utils/StackAnimationProgressContext';
 import StackAnimationIsSwipingContext from '../../utils/StackAnimationIsSwipingContext';
 
 type Props = ViewProps & {
@@ -851,59 +852,63 @@ export default class Card extends React.Component<Props> {
 
     return (
       <StackGestureContext.Provider value={this.gestureRef}>
-        <StackAnimationIsSwipingContext.Provider value={this.isSwiping}>
-          <View pointerEvents="box-none" {...rest}>
-            <Animated.Code
-              key={gestureEnabled ? 'gesture-code' : 'no-gesture-code'}
-              exec={gestureEnabled ? this.execWithGesture : this.execNoGesture}
-            />
-            {overlayEnabled && overlayStyle ? (
-              <Animated.View
-                pointerEvents="none"
-                style={[styles.overlay, overlayStyle]}
-              />
-            ) : null}
+        <View pointerEvents="box-none" {...rest}>
+          <Animated.Code
+            key={gestureEnabled ? 'gesture-code' : 'no-gesture-code'}
+            exec={gestureEnabled ? this.execWithGesture : this.execNoGesture}
+          />
+          {overlayEnabled && overlayStyle ? (
             <Animated.View
-              style={[styles.container, containerStyle, customContainerStyle]}
-              pointerEvents="box-none"
+              pointerEvents="none"
+              style={[styles.overlay, overlayStyle]}
+            />
+          ) : null}
+          <Animated.View
+            style={[styles.container, containerStyle, customContainerStyle]}
+            pointerEvents="box-none"
+          >
+            <PanGestureHandler
+              ref={this.gestureRef}
+              enabled={layout.width !== 0 && gestureEnabled}
+              onGestureEvent={handleGestureEvent}
+              onHandlerStateChange={handleGestureEvent}
+              {...this.gestureActivationCriteria()}
             >
-              <PanGestureHandler
-                ref={this.gestureRef}
-                enabled={layout.width !== 0 && gestureEnabled}
-                onGestureEvent={handleGestureEvent}
-                onHandlerStateChange={handleGestureEvent}
-                {...this.gestureActivationCriteria()}
-              >
-                <Animated.View style={[styles.container, cardStyle]}>
-                  {shadowEnabled && shadowStyle && !transparent ? (
-                    <Animated.View
-                      style={[
-                        styles.shadow,
-                        gestureDirection === 'horizontal'
-                          ? styles.shadowHorizontal
-                          : styles.shadowVertical,
-                        shadowStyle,
-                      ]}
-                      pointerEvents="none"
-                    />
-                  ) : null}
-                  <PointerEventsView
-                    active={active}
-                    progress={this.props.current}
+              <Animated.View style={[styles.container, cardStyle]}>
+                {shadowEnabled && shadowStyle && !transparent ? (
+                  <Animated.View
                     style={[
-                      styles.content,
-                      overrideFlex,
-                      transparent ? styles.transparent : styles.opaque,
-                      contentStyle,
+                      styles.shadow,
+                      gestureDirection === 'horizontal'
+                        ? styles.shadowHorizontal
+                        : styles.shadowVertical,
+                      shadowStyle,
                     ]}
-                  >
-                    {children}
-                  </PointerEventsView>
-                </Animated.View>
-              </PanGestureHandler>
-            </Animated.View>
-          </View>
-        </StackAnimationIsSwipingContext.Provider>
+                    pointerEvents="none"
+                  />
+                ) : null}
+                <PointerEventsView
+                  active={active}
+                  progress={this.props.current}
+                  style={[
+                    styles.content,
+                    overrideFlex,
+                    transparent ? styles.transparent : styles.opaque,
+                    contentStyle,
+                  ]}
+                >
+                  <StackAnimationProgressContext.Provider value={current}>
+                    <StackAnimationIsSwipingContext.Provider
+                      value={this.isSwiping}
+                    >
+                      {children}
+                    </StackAnimationIsSwipingContext.Provider>
+                  </StackAnimationProgressContext.Provider>
+                </PointerEventsView>
+              </Animated.View>
+            </PanGestureHandler>
+          </Animated.View>
+        </View>
       </StackGestureContext.Provider>
     );
   }

--- a/src/views/Stack/Card.tsx
+++ b/src/views/Stack/Card.tsx
@@ -25,6 +25,7 @@ import {
 import memoize from '../../utils/memoize';
 import StackGestureContext from '../../utils/StackGestureContext';
 import PointerEventsView from './PointerEventsView';
+import StackAnimationIsSwipingContext from '../../utils/StackAnimationIsSwipingContext';
 
 type Props = ViewProps & {
   index: number;
@@ -842,57 +843,59 @@ export default class Card extends React.Component<Props> {
 
     return (
       <StackGestureContext.Provider value={this.gestureRef}>
-        <View pointerEvents="box-none" {...rest}>
-          <Animated.Code
-            key={gestureEnabled ? 'gesture-code' : 'no-gesture-code'}
-            exec={gestureEnabled ? this.execWithGesture : this.execNoGesture}
-          />
-          {overlayEnabled && overlayStyle ? (
-            <Animated.View
-              pointerEvents="none"
-              style={[styles.overlay, overlayStyle]}
+        <StackAnimationIsSwipingContext.Provider value={this.isSwiping}>
+          <View pointerEvents="box-none" {...rest}>
+            <Animated.Code
+              key={gestureEnabled ? 'gesture-code' : 'no-gesture-code'}
+              exec={gestureEnabled ? this.execWithGesture : this.execNoGesture}
             />
-          ) : null}
-          <Animated.View
-            style={[styles.container, containerStyle, customContainerStyle]}
-            pointerEvents="box-none"
-          >
-            <PanGestureHandler
-              ref={this.gestureRef}
-              enabled={layout.width !== 0 && gestureEnabled}
-              onGestureEvent={handleGestureEvent}
-              onHandlerStateChange={handleGestureEvent}
-              {...this.gestureActivationCriteria()}
+            {overlayEnabled && overlayStyle ? (
+              <Animated.View
+                pointerEvents="none"
+                style={[styles.overlay, overlayStyle]}
+              />
+            ) : null}
+            <Animated.View
+              style={[styles.container, containerStyle, customContainerStyle]}
+              pointerEvents="box-none"
             >
-              <Animated.View style={[styles.container, cardStyle]}>
-                {shadowEnabled && shadowStyle && !transparent ? (
-                  <Animated.View
+              <PanGestureHandler
+                ref={this.gestureRef}
+                enabled={layout.width !== 0 && gestureEnabled}
+                onGestureEvent={handleGestureEvent}
+                onHandlerStateChange={handleGestureEvent}
+                {...this.gestureActivationCriteria()}
+              >
+                <Animated.View style={[styles.container, cardStyle]}>
+                  {shadowEnabled && shadowStyle && !transparent ? (
+                    <Animated.View
+                      style={[
+                        styles.shadow,
+                        gestureDirection === 'horizontal'
+                          ? styles.shadowHorizontal
+                          : styles.shadowVertical,
+                        shadowStyle,
+                      ]}
+                      pointerEvents="none"
+                    />
+                  ) : null}
+                  <PointerEventsView
+                    active={active}
+                    progress={this.props.current}
                     style={[
-                      styles.shadow,
-                      gestureDirection === 'horizontal'
-                        ? styles.shadowHorizontal
-                        : styles.shadowVertical,
-                      shadowStyle,
+                      styles.content,
+                      overrideFlex,
+                      transparent ? styles.transparent : styles.opaque,
+                      contentStyle,
                     ]}
-                    pointerEvents="none"
-                  />
-                ) : null}
-                <PointerEventsView
-                  active={active}
-                  progress={this.props.current}
-                  style={[
-                    styles.content,
-                    overrideFlex,
-                    transparent ? styles.transparent : styles.opaque,
-                    contentStyle,
-                  ]}
-                >
-                  {children}
-                </PointerEventsView>
-              </Animated.View>
-            </PanGestureHandler>
-          </Animated.View>
-        </View>
+                  >
+                    {children}
+                  </PointerEventsView>
+                </Animated.View>
+              </PanGestureHandler>
+            </Animated.View>
+          </View>
+        </StackAnimationIsSwipingContext.Provider>
       </StackGestureContext.Provider>
     );
   }

--- a/src/views/Stack/Card.tsx
+++ b/src/views/Stack/Card.tsx
@@ -27,6 +27,7 @@ import StackGestureContext from '../../utils/StackGestureContext';
 import PointerEventsView from './PointerEventsView';
 import StackAnimationProgressContext from '../../utils/StackAnimationProgressContext';
 import StackAnimationIsSwipingContext from '../../utils/StackAnimationIsSwipingContext';
+import StackAnimationIsClosingContext from '../../utils/StackAnimationIsClosingContext';
 
 type Props = ViewProps & {
   index: number;
@@ -901,7 +902,11 @@ export default class Card extends React.Component<Props> {
                     <StackAnimationIsSwipingContext.Provider
                       value={this.isSwiping}
                     >
-                      {children}
+                      <StackAnimationIsClosingContext.Provider
+                        value={this.isClosing}
+                      >
+                        {children}
+                      </StackAnimationIsClosingContext.Provider>
                     </StackAnimationIsSwipingContext.Provider>
                   </StackAnimationProgressContext.Provider>
                 </PointerEventsView>

--- a/src/views/Stack/Stack.tsx
+++ b/src/views/Stack/Stack.tsx
@@ -28,6 +28,7 @@ import {
   SceneDescriptorMap,
   NavigationStackOptions,
 } from '../../types';
+import StackAnimationProgressContext from '../../utils/StackAnimationProgressContext';
 
 type ProgressValues = {
   [key: string]: Animated.Value<number>;
@@ -334,154 +335,158 @@ export default class Stack extends React.Component<Props, State> {
     }
 
     return (
-      <React.Fragment>
-        <MaybeScreenContainer
-          enabled={mode !== 'modal'}
-          style={styles.container}
-          onLayout={this.handleLayout}
-        >
-          {routes.map((route, index, self) => {
-            const focused = focusedRoute.key === route.key;
-            const current = progress[route.key];
-            const scene = scenes[index];
-            const next = self[index + 1]
-              ? progress[self[index + 1].key]
-              : ANIMATED_ONE;
+      <StackAnimationProgressContext.Provider value={progress}>
+        <React.Fragment>
+          <MaybeScreenContainer
+            enabled={mode !== 'modal'}
+            style={styles.container}
+            onLayout={this.handleLayout}
+          >
+            {routes.map((route, index, self) => {
+              const focused = focusedRoute.key === route.key;
+              const current = progress[route.key];
+              const scene = scenes[index];
+              const next = self[index + 1]
+                ? progress[self[index + 1].key]
+                : ANIMATED_ONE;
 
-            // Display current screen and a screen beneath. On Android screen beneath is hidden on animation finished bs of RNS's issue.
-            const isScreenActive =
-              index === self.length - 1
-                ? 1
-                : Platform.OS === 'android'
-                ? cond(eq(next, 1), 0, 1)
-                : index === self.length - 2
-                ? 1
-                : 0;
+              // Display current screen and a screen beneath. On Android screen beneath is hidden on animation finished bs of RNS's issue.
+              const isScreenActive =
+                index === self.length - 1
+                  ? 1
+                  : Platform.OS === 'android'
+                  ? cond(eq(next, 1), 0, 1)
+                  : index === self.length - 2
+                  ? 1
+                  : 0;
 
-            if (
-              process.env.NODE_ENV !== 'production' &&
-              scene.descriptor &&
-              scene.descriptor.options
-            ) {
-              validateDeprecatedOptions(scene.descriptor.options);
-            }
-
-            const {
-              header,
-              headerShown,
-              headerTransparent,
-              cardTransparent,
-              cardShadowEnabled,
-              cardOverlayEnabled,
-              cardStyle,
-              gestureResponseDistance,
-              gestureDirection = defaultTransitionPreset.gestureDirection,
-              transitionSpec = defaultTransitionPreset.transitionSpec,
-              cardStyleInterpolator = defaultTransitionPreset.cardStyleInterpolator,
-              headerStyleInterpolator = defaultTransitionPreset.headerStyleInterpolator,
-              gestureVelocityImpact,
-            } = scene.descriptor
-              ? scene.descriptor.options
-              : ({} as NavigationStackOptions);
-
-            let transitionConfig = {
-              transitionSpec,
-              cardStyleInterpolator,
-              headerStyleInterpolator,
-            };
-
-            // When a screen is not the last, it should use next screen's transition config
-            // Many transitions also animate the previous screen, so using 2 different transitions doesn't look right
-            // For example combining a slide and a modal transition would look wrong otherwise
-            // With this approach, combining different transition styles in the same navigator mostly looks right
-            // This will still be broken when 2 transitions have different idle state (e.g. modal presentation),
-            // but majority of the transitions look alright
-            if (index !== self.length - 1) {
-              const nextScene = scenes[index + 1];
-
-              if (nextScene) {
-                const {
-                  transitionSpec = defaultTransitionPreset.transitionSpec,
-                  cardStyleInterpolator = defaultTransitionPreset.cardStyleInterpolator,
-                  headerStyleInterpolator = defaultTransitionPreset.headerStyleInterpolator,
-                } = nextScene.descriptor
-                  ? nextScene.descriptor.options
-                  : ({} as NavigationStackOptions);
-
-                transitionConfig = {
-                  transitionSpec,
-                  cardStyleInterpolator,
-                  headerStyleInterpolator,
-                };
+              if (
+                process.env.NODE_ENV !== 'production' &&
+                scene.descriptor &&
+                scene.descriptor.options
+              ) {
+                validateDeprecatedOptions(scene.descriptor.options);
               }
-            }
 
-            return (
-              <MaybeScreen
-                key={route.key}
-                style={StyleSheet.absoluteFill}
-                enabled={mode !== 'modal'}
-                active={isScreenActive}
-                pointerEvents="box-none"
-              >
-                <StackItem
-                  index={index}
-                  active={index === self.length - 1}
-                  focused={focused}
-                  closing={closingRoutesKeys.includes(route.key)}
-                  layout={layout}
-                  current={current}
-                  scene={scene}
-                  previousScene={scenes[index - 1]}
-                  navigation={navigation}
-                  cardTransparent={cardTransparent}
-                  cardOverlayEnabled={cardOverlayEnabled}
-                  cardShadowEnabled={cardShadowEnabled}
-                  cardStyle={cardStyle}
-                  onPageChangeStart={onPageChangeStart}
-                  onPageChangeConfirm={onPageChangeConfirm}
-                  onPageChangeCancel={onPageChangeCancel}
-                  floatingHeaderHeight={floatingHeaderHeights[route.key]}
-                  headerShown={header !== null && headerShown !== false}
-                  getPreviousRoute={getPreviousRoute}
-                  headerMode={headerMode}
-                  headerTransparent={headerTransparent}
-                  renderHeader={renderHeader}
-                  renderScene={renderScene}
-                  onOpenRoute={onOpenRoute}
-                  onCloseRoute={onCloseRoute}
-                  onTransitionStart={this.handleTransitionStart}
-                  onTransitionEnd={this.handleTransitionEnd}
-                  onGoBack={onGoBack}
-                  gestureDirection={gestureDirection}
-                  transitionSpec={transitionSpec}
-                  cardStyleInterpolator={cardStyleInterpolator}
-                  headerStyleInterpolator={headerStyleInterpolator}
-                  gestureEnabled={index !== 0 && getGesturesEnabled({ route })}
-                  gestureResponseDistance={gestureResponseDistance}
-                  gestureVelocityImpact={gestureVelocityImpact}
-                  {...transitionConfig}
-                />
-              </MaybeScreen>
-            );
-          })}
-        </MaybeScreenContainer>
-        {headerMode === 'float'
-          ? renderHeader({
-              mode: 'float',
-              layout,
-              scenes,
-              navigation,
-              getPreviousRoute,
-              onContentHeightChange: this.handleFloatingHeaderLayout,
-              styleInterpolator:
-                focusedOptions.headerStyleInterpolator !== undefined
-                  ? focusedOptions.headerStyleInterpolator
-                  : defaultTransitionPreset.headerStyleInterpolator,
-              style: styles.floating,
-            })
-          : null}
-      </React.Fragment>
+              const {
+                header,
+                headerShown,
+                headerTransparent,
+                cardTransparent,
+                cardShadowEnabled,
+                cardOverlayEnabled,
+                cardStyle,
+                gestureResponseDistance,
+                gestureDirection = defaultTransitionPreset.gestureDirection,
+                transitionSpec = defaultTransitionPreset.transitionSpec,
+                cardStyleInterpolator = defaultTransitionPreset.cardStyleInterpolator,
+                headerStyleInterpolator = defaultTransitionPreset.headerStyleInterpolator,
+                gestureVelocityImpact,
+              } = scene.descriptor
+                ? scene.descriptor.options
+                : ({} as NavigationStackOptions);
+
+              let transitionConfig = {
+                transitionSpec,
+                cardStyleInterpolator,
+                headerStyleInterpolator,
+              };
+
+              // When a screen is not the last, it should use next screen's transition config
+              // Many transitions also animate the previous screen, so using 2 different transitions doesn't look right
+              // For example combining a slide and a modal transition would look wrong otherwise
+              // With this approach, combining different transition styles in the same navigator mostly looks right
+              // This will still be broken when 2 transitions have different idle state (e.g. modal presentation),
+              // but majority of the transitions look alright
+              if (index !== self.length - 1) {
+                const nextScene = scenes[index + 1];
+
+                if (nextScene) {
+                  const {
+                    transitionSpec = defaultTransitionPreset.transitionSpec,
+                    cardStyleInterpolator = defaultTransitionPreset.cardStyleInterpolator,
+                    headerStyleInterpolator = defaultTransitionPreset.headerStyleInterpolator,
+                  } = nextScene.descriptor
+                    ? nextScene.descriptor.options
+                    : ({} as NavigationStackOptions);
+
+                  transitionConfig = {
+                    transitionSpec,
+                    cardStyleInterpolator,
+                    headerStyleInterpolator,
+                  };
+                }
+              }
+
+              return (
+                <MaybeScreen
+                  key={route.key}
+                  style={StyleSheet.absoluteFill}
+                  enabled={mode !== 'modal'}
+                  active={isScreenActive}
+                  pointerEvents="box-none"
+                >
+                  <StackItem
+                    index={index}
+                    active={index === self.length - 1}
+                    focused={focused}
+                    closing={closingRoutesKeys.includes(route.key)}
+                    layout={layout}
+                    current={current}
+                    scene={scene}
+                    previousScene={scenes[index - 1]}
+                    navigation={navigation}
+                    cardTransparent={cardTransparent}
+                    cardOverlayEnabled={cardOverlayEnabled}
+                    cardShadowEnabled={cardShadowEnabled}
+                    cardStyle={cardStyle}
+                    onPageChangeStart={onPageChangeStart}
+                    onPageChangeConfirm={onPageChangeConfirm}
+                    onPageChangeCancel={onPageChangeCancel}
+                    floatingHeaderHeight={floatingHeaderHeights[route.key]}
+                    headerShown={header !== null && headerShown !== false}
+                    getPreviousRoute={getPreviousRoute}
+                    headerMode={headerMode}
+                    headerTransparent={headerTransparent}
+                    renderHeader={renderHeader}
+                    renderScene={renderScene}
+                    onOpenRoute={onOpenRoute}
+                    onCloseRoute={onCloseRoute}
+                    onTransitionStart={this.handleTransitionStart}
+                    onTransitionEnd={this.handleTransitionEnd}
+                    onGoBack={onGoBack}
+                    gestureDirection={gestureDirection}
+                    transitionSpec={transitionSpec}
+                    cardStyleInterpolator={cardStyleInterpolator}
+                    headerStyleInterpolator={headerStyleInterpolator}
+                    gestureEnabled={
+                      index !== 0 && getGesturesEnabled({ route })
+                    }
+                    gestureResponseDistance={gestureResponseDistance}
+                    gestureVelocityImpact={gestureVelocityImpact}
+                    {...transitionConfig}
+                  />
+                </MaybeScreen>
+              );
+            })}
+          </MaybeScreenContainer>
+          {headerMode === 'float'
+            ? renderHeader({
+                mode: 'float',
+                layout,
+                scenes,
+                navigation,
+                getPreviousRoute,
+                onContentHeightChange: this.handleFloatingHeaderLayout,
+                styleInterpolator:
+                  focusedOptions.headerStyleInterpolator !== undefined
+                    ? focusedOptions.headerStyleInterpolator
+                    : defaultTransitionPreset.headerStyleInterpolator,
+                style: styles.floating,
+              })
+            : null}
+        </React.Fragment>
+      </StackAnimationProgressContext.Provider>
     );
   }
 }

--- a/src/views/Stack/Stack.tsx
+++ b/src/views/Stack/Stack.tsx
@@ -441,9 +441,7 @@ export default class Stack extends React.Component<Props, State> {
                 active={isScreenActive}
                 pointerEvents="box-none"
               >
-                <StackAnimationProgressContext.Provider
-                  value={{ current, next }}
-                >
+                <StackAnimationProgressContext.Provider value={current}>
                   <StackItem
                     index={index}
                     active={index === self.length - 1}

--- a/src/views/Stack/Stack.tsx
+++ b/src/views/Stack/Stack.tsx
@@ -28,7 +28,6 @@ import {
   SceneDescriptorMap,
   NavigationStackOptions,
 } from '../../types';
-import StackAnimationProgressContext from '../../utils/StackAnimationProgressContext';
 
 type ProgressValues = {
   [key: string]: Animated.Value<number>;
@@ -441,52 +440,48 @@ export default class Stack extends React.Component<Props, State> {
                 active={isScreenActive}
                 pointerEvents="box-none"
               >
-                <StackAnimationProgressContext.Provider value={current}>
-                  <StackItem
-                    index={index}
-                    active={index === self.length - 1}
-                    focused={focused}
-                    closing={closingRoutesKeys.includes(route.key)}
-                    layout={layout}
-                    current={current}
-                    scene={scene}
-                    previousScene={scenes[index - 1]}
-                    navigation={navigation}
-                    safeAreaInsetTop={safeAreaInsetTop}
-                    safeAreaInsetRight={safeAreaInsetRight}
-                    safeAreaInsetBottom={safeAreaInsetBottom}
-                    safeAreaInsetLeft={safeAreaInsetLeft}
-                    cardTransparent={cardTransparent}
-                    cardOverlayEnabled={cardOverlayEnabled}
-                    cardShadowEnabled={cardShadowEnabled}
-                    cardStyle={cardStyle}
-                    onPageChangeStart={onPageChangeStart}
-                    onPageChangeConfirm={onPageChangeConfirm}
-                    onPageChangeCancel={onPageChangeCancel}
-                    floatingHeaderHeight={floatingHeaderHeights[route.key]}
-                    headerShown={header !== null && headerShown !== false}
-                    getPreviousRoute={getPreviousRoute}
-                    headerMode={headerMode}
-                    headerTransparent={headerTransparent}
-                    renderHeader={renderHeader}
-                    renderScene={renderScene}
-                    onOpenRoute={onOpenRoute}
-                    onCloseRoute={onCloseRoute}
-                    onTransitionStart={this.handleTransitionStart}
-                    onTransitionEnd={this.handleTransitionEnd}
-                    onGoBack={onGoBack}
-                    gestureDirection={gestureDirection}
-                    transitionSpec={transitionSpec}
-                    cardStyleInterpolator={cardStyleInterpolator}
-                    headerStyleInterpolator={headerStyleInterpolator}
-                    gestureEnabled={
-                      index !== 0 && getGesturesEnabled({ route })
-                    }
-                    gestureResponseDistance={gestureResponseDistance}
-                    gestureVelocityImpact={gestureVelocityImpact}
-                    {...transitionConfig}
-                  />
-                </StackAnimationProgressContext.Provider>
+                <StackItem
+                  index={index}
+                  active={index === self.length - 1}
+                  focused={focused}
+                  closing={closingRoutesKeys.includes(route.key)}
+                  layout={layout}
+                  current={current}
+                  scene={scene}
+                  previousScene={scenes[index - 1]}
+                  navigation={navigation}
+                  safeAreaInsetTop={safeAreaInsetTop}
+                  safeAreaInsetRight={safeAreaInsetRight}
+                  safeAreaInsetBottom={safeAreaInsetBottom}
+                  safeAreaInsetLeft={safeAreaInsetLeft}
+                  cardTransparent={cardTransparent}
+                  cardOverlayEnabled={cardOverlayEnabled}
+                  cardShadowEnabled={cardShadowEnabled}
+                  cardStyle={cardStyle}
+                  onPageChangeStart={onPageChangeStart}
+                  onPageChangeConfirm={onPageChangeConfirm}
+                  onPageChangeCancel={onPageChangeCancel}
+                  floatingHeaderHeight={floatingHeaderHeights[route.key]}
+                  headerShown={header !== null && headerShown !== false}
+                  getPreviousRoute={getPreviousRoute}
+                  headerMode={headerMode}
+                  headerTransparent={headerTransparent}
+                  renderHeader={renderHeader}
+                  renderScene={renderScene}
+                  onOpenRoute={onOpenRoute}
+                  onCloseRoute={onCloseRoute}
+                  onTransitionStart={this.handleTransitionStart}
+                  onTransitionEnd={this.handleTransitionEnd}
+                  onGoBack={onGoBack}
+                  gestureDirection={gestureDirection}
+                  transitionSpec={transitionSpec}
+                  cardStyleInterpolator={cardStyleInterpolator}
+                  headerStyleInterpolator={headerStyleInterpolator}
+                  gestureEnabled={index !== 0 && getGesturesEnabled({ route })}
+                  gestureResponseDistance={gestureResponseDistance}
+                  gestureVelocityImpact={gestureVelocityImpact}
+                  {...transitionConfig}
+                />
               </MaybeScreen>
             );
           })}


### PR DESCRIPTION
This PR exposes transition's progress and when user is swiping via context. Both `Animated.Value`'s are passed as value into two new contexts (i.e. `StackAnimationProgressContext` and `StackAnimationIsSwipingContext`). This allows consumers to define custom transitions/animations based on those values. A new example was added in `examples` directory.

<details>
<summary>GIF of example</summary>

![ezgif-1-92544ede7802](https://user-images.githubusercontent.com/20142959/67138094-c038fb80-f20c-11e9-9b90-92851610e4c4.gif)

</details>

Closes https://github.com/react-navigation/stack/issues/183
