### PR TITLE
Handle keyboard reappearance for short interaction

### DIFF
--- a/src/views/KeyboardManager.tsx
+++ b/src/views/KeyboardManager.tsx
@@ -13,6 +13,7 @@ export default class KeyboardManager extends React.Component<Props> {
   // Numeric id of the previously focused text input
   // When a gesture didn't change the tab, we can restore the focused input with this
   private previouslyFocusedTextInput: number | null = null;
+  private startTimestamp: number | null = null;
 
   private handlePageChangeStart = () => {
     const input = TextInput.State.currentlyFocusedField();
@@ -22,6 +23,9 @@ export default class KeyboardManager extends React.Component<Props> {
 
     // Store the id of this input so we can refocus it if change was cancelled
     this.previouslyFocusedTextInput = input;
+
+    // Store timestamp for touch start
+    this.startTimestamp = Date.now();
   };
 
   private handlePageChangeConfirm = () => {
@@ -36,10 +40,17 @@ export default class KeyboardManager extends React.Component<Props> {
     const input = this.previouslyFocusedTextInput;
 
     if (input) {
-      TextInput.State.focusTextInput(input);
+      // If the interaction was super short we should make sure keyboard won't hide again
+      if (Date.now() - this.startTimestamp < 100) {
+        setTimeout(() => {
+          TextInput.State.focusTextInput(input);          
+          this.previouslyFocusedTextInput = null;
+        }, 100);
+      } else {
+        TextInput.State.focusTextInput(input);
+        this.previouslyFocusedTextInput = null;
+      }
     }
-
-    this.previouslyFocusedTextInput = null;
   };
 
   render() {


### PR DESCRIPTION
When user has super short swiping interaction it's an issue that keyboard won't reappear on screen. 
That's because there is short time when system will make sure to hide keyboard no matter what. Too fast text input refocus will result only in keyboard flashing on screen and hiding right away.

For such short interactions I created a delay that will ensure that the keyboard will reappear on the screen every time and make sure it's executed only when needed.
It only affect super short interactions <100ms to make sure they work correctly, and doesn't affect any logic beyond that. 

As far as my research go it seems that the react-navigation isn't responsible for hiding the Keyboard in that specific case, so I don't think we can simply prevent this action when we don't want it. Doing the check in KeyboardMenager and delaying it is the safest way IMO - we make sure that it won't affect any other logic than concerning keyboard itself. (It would happen if we prevent the action somewhere else like in StackItem)

Before fix: 
![ezgif-1-41c6a9de9e30](https://user-images.githubusercontent.com/42337257/67392718-57050f80-f5a1-11e9-84d2-24b143e37948.gif)

After fix: 
![ezgif-1-df2ffb1836d1](https://user-images.githubusercontent.com/42337257/67392531-ff66a400-f5a0-11e9-877d-4a46a7589312.gif)
