### PR TITLE
fix: add ^2.0.0-alpha to react-native-screens peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "react-native-gesture-handler": "^1.0.0",
     "react-native-reanimated": "^1.3.0-alpha",
     "react-native-safe-area-context": "^0.3.3",
-    "react-native-screens": "^1.0.0 || ^1.0.0-alpha",
+    "react-native-screens": "^1.0.0 || ^1.0.0-alpha || ^2.0.0-alpha",
     "react-navigation": "^4.0.7"
   },
   "jest": {


### PR DESCRIPTION
Since using `react-navigation-stack` with `react-native-screens ^2.0.0-alpha` does not represent an issue, it just causes an annoying warning when linking dependencies.