### PR TITLE
[WIP] fix: set default numberOfLines prop to 1 in HeaderTitle

### DIFF
--- a/src/navigators/__tests__/__snapshots__/NestedNavigator.test.tsx.snap
+++ b/src/navigators/__tests__/__snapshots__/NestedNavigator.test.tsx.snap
@@ -453,6 +453,7 @@ Array [
                               }
                             >
                               <Text
+                                numberOfLines={1}
                                 onLayout={[Function]}
                                 style={
                                   Array [
@@ -593,6 +594,7 @@ Array [
             }
           >
             <Text
+              numberOfLines={1}
               onLayout={[Function]}
               style={
                 Array [

--- a/src/navigators/__tests__/__snapshots__/StackNavigator.test.tsx.snap
+++ b/src/navigators/__tests__/__snapshots__/StackNavigator.test.tsx.snap
@@ -288,6 +288,7 @@ Array [
             }
           >
             <Text
+              numberOfLines={1}
               onLayout={[Function]}
               style={
                 Array [
@@ -627,6 +628,7 @@ Array [
             }
           >
             <Text
+              numberOfLines={1}
               onLayout={[Function]}
               style={
                 Array [

--- a/src/views/Header/HeaderTitle.tsx
+++ b/src/views/Header/HeaderTitle.tsx
@@ -7,7 +7,9 @@ type Props = TextProps & {
 };
 
 export default function HeaderTitle({ style, ...rest }: Props) {
-  return <Animated.Text {...rest} style={[styles.title, style]} />;
+  return (
+    <Animated.Text numberOfLines={1} {...rest} style={[styles.title, style]} />
+  );
 }
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
## Description
I added back default numberOfLines prop to the HeaderTitle Component. It will truncate the default title text. [#290] 
This PR would not fix the above issue, because HeaderTitle still overlaps on the headerLeft and/or headerRight.
![IMG_0308](https://user-images.githubusercontent.com/11720377/69038324-dee80900-09e9-11ea-845c-b789ed1fe08b.PNG)

## Next steps
I'm not sure how you would like to handle positioning in the Header Component if text is long (overlaps).
