### PR TITLE
fix: children touch events leaking to underlying Header right/left components

### DIFF
--- a/src/views/Header/HeaderContainer.tsx
+++ b/src/views/Header/HeaderContainer.tsx
@@ -109,9 +109,7 @@ export default function HeaderContainer({
                       })
                   : undefined
               }
-              pointerEvents={
-                isFocused ? 'box-none' : 'none'
-              }
+              pointerEvents={isFocused ? 'box-none' : 'none'}
               accessibilityElementsHidden={!isFocused}
               importantForAccessibility={
                 isFocused ? 'auto' : 'no-hide-descendants'

--- a/src/views/Header/HeaderContainer.tsx
+++ b/src/views/Header/HeaderContainer.tsx
@@ -109,7 +109,9 @@ export default function HeaderContainer({
                       })
                   : undefined
               }
-              pointerEvents="box-none"
+              pointerEvents={
+                isFocused ? 'box-none' : 'none'
+              }
               accessibilityElementsHidden={!isFocused}
               importantForAccessibility={
                 isFocused ? 'auto' : 'no-hide-descendants'


### PR DESCRIPTION
Issue reproduction:
1. Add a custom touchable element to either headerLeft or right.
2. Push a new screen
3. You are still able to press the underlying element even if it's not visible.