### PR TITLE
fix: include scripts dir required for postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "sideEffects": false,
   "files": [
     "src",
-    "lib"
+    "lib",
+    "scripts"
   ],
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
Solves this issue I encountered when trying to install `react-navigation-stack@2.0.0-alpha.41`:

```
> react-navigation-stack@2.0.0-alpha.41 postinstall /Users/shirakaba/git/my_app/node_modules/react-navigation-stack
> bash scripts/sync-stack.sh

bash: scripts/sync-stack.sh: No such file or directory
```