### PR TITLE
fix: set Android HeaderTitle fontWeight to 'bold' (#308)

### DIFF
--- a/src/views/Header/HeaderTitle.tsx
+++ b/src/views/Header/HeaderTitle.tsx
@@ -35,7 +35,7 @@ const styles = StyleSheet.create({
       },
       android: {
         fontSize: 20,
-        fontWeight: '500',
+        fontWeight: 'bold',
         color: 'rgba(0, 0, 0, .9)',
         marginHorizontal: 16,
       },


### PR DESCRIPTION
Fixes #308 for the 1.0 branch by restoring the pre-RN-0.60 behavior (before RN 0.60, font weights >= 500 were mapped to `'bold'` on Android).